### PR TITLE
fix invalid dma2 address for stm32 cpus

### DIFF
--- a/platforms/cpus/stm32f4.repl
+++ b/platforms/cpus/stm32f4.repl
@@ -74,7 +74,7 @@ spi3: SPI.STM32SPI @ sysbus 0x40003C00
 dma1: DMA.STM32DMA @ sysbus 0x40026000
     [0-7] -> nvic@[11-17,47]
 
-dma2: DMA.STM32DMA @ sysbus 0x40023400
+dma2: DMA.STM32DMA @ sysbus 0x40026400
     [0-7] -> nvic@[56-60,68-70]
 
 rng: Miscellaneous.STM32F4_RNG @ sysbus 0x50060800

--- a/platforms/cpus/stm32f429.repl
+++ b/platforms/cpus/stm32f429.repl
@@ -72,7 +72,7 @@ spi3: SPI.STM32SPI @ sysbus 0x40003C00
 dma1: DMA.STM32DMA @ sysbus 0x40026000
     [0-7] -> nvic@[11-17,47]
 
-dma2: DMA.STM32DMA @ sysbus 0x40023400
+dma2: DMA.STM32DMA @ sysbus 0x40026400
     [0-7] -> nvic@[56-60,68-70]
 
 ltdc: Video.STM32LTDC @ sysbus 0x40016800

--- a/platforms/cpus/stm32f746.repl
+++ b/platforms/cpus/stm32f746.repl
@@ -77,7 +77,7 @@ spi3: SPI.STM32SPI @ sysbus 0x40003C00
 dma1: DMA.STM32DMA @ sysbus 0x40026000
     [0-7] -> nvic@[11-17,47]
 
-dma2: DMA.STM32DMA @ sysbus 0x40023400
+dma2: DMA.STM32DMA @ sysbus 0x40026400
     [0-7] -> nvic@[56-60,68-70]
 
 ltdc: Video.STM32LTDC @ sysbus 0x40016800


### PR DESCRIPTION
stm32f cpu contains invalid dma2 address