### PR TITLE
[#92] fix stm32f4_disco board description file

### DIFF
--- a/platforms/boards/stm32f4_discovery.repl
+++ b/platforms/boards/stm32f4_discovery.repl
@@ -6,5 +6,9 @@ UserButton: Miscellaneous.Button @ gpioPortA
 UserLED: Miscellaneous.LED @ gpioPortD
 
 gpioPortD:
-    12 -> gpioPortD@0  
-   
+    12 -> gpioPortD@0
+
+rcc: Python.PythonPeripheral @ sysbus 0x40023800
+    size: 0x400
+    initable: true
+    filename: "scripts/pydev/flipflop.py"

--- a/platforms/boards/stm32f4_discovery.repl
+++ b/platforms/boards/stm32f4_discovery.repl
@@ -7,8 +7,3 @@ UserLED: Miscellaneous.LED @ gpioPortD
 
 gpioPortD:
     12 -> gpioPortD@0
-
-rcc: Python.PythonPeripheral @ sysbus 0x40023800
-    size: 0x400
-    initable: true
-    filename: "scripts/pydev/flipflop.py"

--- a/platforms/cpus/stm32f4.repl
+++ b/platforms/cpus/stm32f4.repl
@@ -80,6 +80,11 @@ dma2: DMA.STM32DMA @ sysbus 0x40023400
 rng: Miscellaneous.STM32F4_RNG @ sysbus 0x50060800
     -> nvic@80
 
+rcc: Python.PythonPeripheral @ sysbus 0x40023800
+    size: 0x400
+    initable: true
+    filename: "scripts/pydev/flipflop.py"
+
 sysbus:
     init:
         ApplySVD @https://dl.antmicro.com/projects/renode/svd/STM32F40x.svd.gz


### PR DESCRIPTION
Zephyr "Hello world" demo binary compiled for this hardware with Zephyr doesn't run because of the missing rcc register. This MR declare the corresponding memory space.