### PR TITLE
 Adding basic support for NXP-K64F

### DIFF
--- a/platforms/boards/mpfs-icicle-kit.repl
+++ b/platforms/boards/mpfs-icicle-kit.repl
@@ -1,0 +1,12 @@
+using "platforms/cpus/polarfire-soc.repl"
+
+gpio0: @ none
+gpio1: @ none
+
+led0: Miscellaneous.LED @ gpio2 16
+led1: Miscellaneous.LED @ gpio2 17
+led2: Miscellaneous.LED @ gpio2 18
+led3: Miscellaneous.LED @ gpio2 19
+
+button1: Miscellaneous.Button @ gpio2 30
+button2: Miscellaneous.Button @ gpio2 31

--- a/platforms/cpus/nxp-k6xf.repl
+++ b/platforms/cpus/nxp-k6xf.repl
@@ -1,0 +1,36 @@
+sram_l: Memory.MappedMemory @ sysbus 0x1fff0000
+    size: 0x10000
+
+sram: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x30000
+
+flash: Memory.MappedMemory @ sysbus 0x0
+    size: 0x100000
+
+uart0: UART.K6xF_UART @ sysbus 0x4006A000
+    IRQ -> nvic@31
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    systickFrequency: 120000000
+    IRQ -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m4f"
+    nvic: nvic
+
+mcg: Miscellaneous.K6xF_MCG @ sysbus 0x40064000
+
+sim: Miscellaneous.K6xF_SIM @ sysbus 0x40047000
+
+eth: Network.K6xF_Ethernet @ sysbus 0x400C0000
+    txIRQ -> nvic@83
+    rxIRQ -> nvic@84
+
+rng: Miscellaneous.K6xF_RNG @ sysbus 0x40029000
+    IRQ -> nvic@23
+
+
+sysbus:
+    init:
+        ApplySVD @https://dl.antmicro.com/projects/renode/svd/MK64F12.svd.gz
+

--- a/platforms/cpus/nxp-k6xf.repl
+++ b/platforms/cpus/nxp-k6xf.repl
@@ -32,5 +32,5 @@ rng: Miscellaneous.K6xF_RNG @ sysbus 0x40029000
 
 sysbus:
     init:
-        ApplySVD @/home/schroer/Downloads/svd/MK64F12.svd.gz
+        ApplySVD @https://dl.antmicro.com/projects/renode/svd/MK64F12.svd.gz
 

--- a/platforms/cpus/nxp-k6xf.repl
+++ b/platforms/cpus/nxp-k6xf.repl
@@ -32,5 +32,5 @@ rng: Miscellaneous.K6xF_RNG @ sysbus 0x40029000
 
 sysbus:
     init:
-        ApplySVD @https://dl.antmicro.com/projects/renode/svd/MK64F12.svd.gz
+        ApplySVD @/home/schroer/Downloads/svd/MK64F12.svd.gz
 

--- a/tests/platforms/NXP-K64F.robot
+++ b/tests/platforms/NXP-K64F.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Documentation                 Testing the NXP K64F platform
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Setup                    Reset Emulation
+Resource                      ${RENODEKEYWORDS}
+
+*** Variables ***
+${UART}                       sysbus.uart0
+${URI}                        @https://dl.antmicro.com/projects/renode
+
+*** Keywords ***
+Create Machine
+    [Arguments]  ${elf}
+
+    Execute Command          mach create
+    Execute Command          machine LoadPlatformDescription @platforms/cpus/nxp-k6xf.repl
+
+    Execute Command          sysbus LoadELF ${URI}/${elf}
+
+    Create Terminal Tester    ${UART}
+
+*** Test Cases ***
+Should Run Zephyr Tests for UART
+    [Documentation]           Runs Zephyr's basic uart tests
+    Create Machine            zephyr_tests_basic_uart-b8c78e254ff875680e99c9f131fbe285c4575927.elf
+
+    Start Emulation
+    Wait For Prompt On Uart   Please send characters to serial console    
+    Write Line To Uart        The quick brown fox jumps over the lazy dog
+    Wait For Prompt On Uart   Please send characters to serial console    
+    Write Line To Uart        The quick brown fox jumps over the lazy dog
+    Wait For Line On Uart     PROJECT EXECUTION SUCCESSFUL
+
+Should Run Zephyr Tests for TCP
+    [Documentation]           Runs Zephyr's tests from tests/net/tcp
+    Create Machine            zephyr_tests_net_tcp-b8c78e254ff875680e99c9f131fbe285c4575927.elf
+
+    Start Emulation
+    Wait For Line On Uart     PROJECT EXECUTION SUCCESSFUL


### PR DESCRIPTION
This PR adds a basic description of the NXP-K64F and robot tests.

This PR depends on https://github.com/renode/renode-infrastructure/pull/17