### PR TITLE
Fix LED connections for STM32* boards

### DIFF
--- a/platforms/boards/stm32f4_discovery-additional_gpios.repl
+++ b/platforms/boards/stm32f4_discovery-additional_gpios.repl
@@ -4,5 +4,5 @@ externalButton: Miscellaneous.Button @ gpioPortA
 externalLed: Miscellaneous.LED @ gpioPortA
 
 gpioPortA:
-    5 -> gpioPortA@0
+    5 -> externalLed@0
 

--- a/platforms/boards/stm32f4_discovery.repl
+++ b/platforms/boards/stm32f4_discovery.repl
@@ -6,5 +6,5 @@ UserButton: Miscellaneous.Button @ gpioPortA
 UserLED: Miscellaneous.LED @ gpioPortD
 
 gpioPortD:
-    12 -> gpioPortD@0  
+    12 -> UserLED@0
    


### PR DESCRIPTION
I think the way the LEDs are connected to the GPIOs on some ST* boards are wrong.

This should fix it