### PR TITLE
plat/cpus/stm32f4: typo in name of FSMC peripheral

### DIFF
--- a/platforms/cpus/stm32f4.repl
+++ b/platforms/cpus/stm32f4.repl
@@ -1,4 +1,4 @@
-fscmBank1: Memory.MappedMemory @ sysbus 0x60000000
+fsmcBank1: Memory.MappedMemory @ sysbus 0x60000000
     size: 0x10000000
 
 sram: Memory.MappedMemory @ sysbus 0x20000000


### PR DESCRIPTION
Minor typo, the peripheral is the flexible static memory controller.

Signed-off-by: Karl Palsson <karlp@etactica.com>