### PR TITLE
plat/cpu/stm32l: Fake all oscillators as ready.

### DIFF
--- a/platforms/cpus/stm32l151.repl
+++ b/platforms/cpus/stm32l151.repl
@@ -85,6 +85,8 @@ sysbus:
         Tag <0x40023C18 4> "FLASH_SR"  0xE
         Tag <0x40007000 4> "PWR_CONTROL" 0x1000
         Tag <0x40007004 4> "PWR_STATUS"  0x8
+        // Hard set all oscillator RDY bits
+        Tag <0x40023800 4> "RCC_CR" 0x2020202
 
 rccCsr: Python.PythonPeripheral @ sysbus 0x40023834
     size: 0x4


### PR DESCRIPTION
Until the STM32L1 gets a "proper" RCC peripheral backend, similar to
Antmicro.Renode.Peripherals.Miscellaneous.STM32F4_RCC, at _least_
provide the oscillator ready bits.  Some/many libraries/apps turn on
oscillators and then check that the oscillator is ready before
continuing.  This patch allows those applications to continue running,
instead of blocking forever.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>