### PR TITLE
platform/cpu/stm32l1: fix system frequency

### DIFF
--- a/platforms/cpus/stm32l151.repl
+++ b/platforms/cpus/stm32l151.repl
@@ -1,6 +1,6 @@
 nvic: IRQControllers.NVIC @ sysbus 0xE000E000
     priorityMask: 0xF0
-    systickFrequency: 168000000
+    systickFrequency: 32000000
     IRQ -> cpu@0
 
 cpu: CPU.CortexM @ sysbus


### PR DESCRIPTION
frequency defaulted to what looked like an F4, instead of L1 max of
32MHz.

Signed-off-by: Karl Palsson <karlp@etactica.com>