### PR TITLE
Added sleep timer IRQ in cc2538 platform file

### DIFF
--- a/platforms/cpus/cc2538.repl
+++ b/platforms/cpus/cc2538.repl
@@ -9,6 +9,7 @@ watchdog: Timers.CC2538Watchdog @ sysbus 0x400D5000
     periodInMs: 500
 
 sleepTimer: Timers.CC2538SleepTimer @ sysbus 0x400D5040
+    -> nvic@145
 
 uart1: UART.PL011 @ sysbus 0x4000D000
     -> nvic@6


### PR DESCRIPTION
Added the sleep timer IRQ (145) of the sleep timer to the platform file of the cc2538 so the compare interrupt of the timer can be used in renode.