### PR TITLE
OpenTitan-earlgrey: Modify platform to pass PLIC and UART sanity tests.

### DIFF
--- a/platforms/cpus/opentitan-earlgrey.repl
+++ b/platforms/cpus/opentitan-earlgrey.repl
@@ -7,21 +7,31 @@ main_ram: Memory.MappedMemory @ sysbus 0x10000000
 flash: Memory.MappedMemory @ sysbus 0x20000000
     size: 0x100000
 
-cpu: CPU.RiscV32 @ sysbus
-    cpuType: "rv32imc" 
-    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+cpu: CPU.IbexRiscV32 @ sysbus
     timeProvider: clint
 
-uart: UART.IbexUART @ sysbus 0x40000000
-    IRQ -> plic@2
+uart: UART.OpenTitan_UART @ sysbus 0x40000000
+    TxWatermarkIRQ -> plic@33
+    RxWatermarkIRQ -> plic@34
+    TxEmptyIRQ -> plic@35
+    RxOverflowIRQ -> plic@36
+    RxFrameErrorIRQ -> plic@37
+    RxBreakErrorIRQ -> plic@38
+    RxTimeoutIRQ -> plic@39
+    RxParityErrorIRQ -> plic@40
+
 
 gpio: GPIOPort.OpenTitan_GPIO @ sysbus 0x40010000
     IRQ -> plic@1
 
-plic: IRQControllers.PlatformLevelInterruptController @ sysbus 0x40090000
-    3 -> cpu@11
-    numberOfSources: 32
+plic: IRQControllers.OpenTitan_PlatformLevelInterruptController @ sysbus 0x40090000
+    0 -> cpu@11
+    numberOfSources: 84
+    numberOfTargets: 1
 
 clint: IRQControllers.CoreLevelInterruptor @ sysbus 0x02000000
     [0,1] -> cpu@[3,7]
     frequency: 62000000
+
+
+swteststatus: Miscellaneous.OpenTitan_VerilatorSwTestStatus @ sysbus 0x30000000


### PR DESCRIPTION
Sets up the PLIC to match the OpenTitan config
Connects the proper UART interrupts to sources on PLIC.

Passes plic sanity test.
 mono Renode.exe -e "\$bin=@opentitan_tests/dif_uart_sanitytest_sim_verilator.elf; i @scripts/single-node/opentitan-earlgrey.resc; machine StartGdbServer 3333" --disable-xwt

