### PR TITLE
Change src/Infrastructure submodule URL path to the absolute URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/Infrastructure"]
 	path = src/Infrastructure
-	url = ../renode-infrastructure.git
+	url = https://github.com/renode/renode-infrastructure.git
 [submodule "lib/termsharp"]
 	path = lib/termsharp
 	url = https://github.com/antmicro/termsharp.git


### PR DESCRIPTION
So `git submodule update` can work outside of `git clone` repo
initialization.

Change-Id: I50134b55c49b85ee3b0a384d634bdf8eb83e974f