### PR TITLE
Replace '#!/bin/bash' with '#!/usr/bin/env bash'.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -u
 set -e

--- a/renode
+++ b/renode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/renode-test
+++ b/renode-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/tools/building/check_weak_implementations.sh
+++ b/tools/building/check_weak_implementations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -u
 set -e
 

--- a/tools/building/createAssemblyInfo.sh
+++ b/tools/building/createAssemblyInfo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Create AssemblyInfo.cs but only when the file does not exists or has different version information
 FILE_NAME="AssemblyInfo"

--- a/tools/building/fetch_libraries.sh
+++ b/tools/building/fetch_libraries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/tools/packaging/conda/build.sh
+++ b/tools/packaging/conda/build.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -x
 
@@ -82,13 +82,13 @@ rm $PREFIX/opt/renode/tests/robot_tests_provider.py.bak
 mkdir -p $PREFIX/bin/
 
 cat > $PREFIX/bin/renode <<"EOF"
-#!/bin/bash
+#!/usr/bin/env bash
 
 mono $MONO_OPTIONS $CONDA_PREFIX/opt/renode/bin/Renode.exe "$@"
 EOF
 
 cat > $PREFIX/bin/renode-test <<"EOF"
-#!/bin/bash
+#!/usr/bin/env bash
 
 STTY_CONFIG=`stty -g 2>/dev/null`
 python3 $CONDA_PREFIX/opt/renode/tests/run_tests.py --robot-framework-remote-server-full-directory $CONDA_PREFIX/opt/renode/bin "$@"

--- a/tools/packaging/export_linux_workdir.sh
+++ b/tools/packaging/export_linux_workdir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/tools/packaging/linux/renode-template
+++ b/tools/packaging/linux/renode-template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LAUNCHER=mono
 

--- a/tools/packaging/make_linux_packages.sh
+++ b/tools/packaging/make_linux_packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/tools/packaging/make_linux_portable.sh
+++ b/tools/packaging/make_linux_portable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/tools/packaging/make_osx_packages.sh
+++ b/tools/packaging/make_osx_packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/tools/packaging/make_windows_packages.sh
+++ b/tools/packaging/make_windows_packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u


### PR DESCRIPTION
Not all systems install bash to /bin/bash (OpenBSD, NetBSD, NixOS.. etc). This
change lets the various build / packaging scripts run on these systems.