### PR TITLE
As per DS00003721A page 1 the TCM is upto 256KB

### DIFF
--- a/platforms/cpus/miv_rv32.repl
+++ b/platforms/cpus/miv_rv32.repl
@@ -4,7 +4,7 @@ cpu: CPU.RiscV32 @ sysbus
     timeProvider: clint
 
 tcm: Memory.MappedMemory @ sysbus 0x40000000
-    size: 0x4000000
+    size: 0x400000
 
 // Power/Reset/Clock/Interrupt
 clint: IRQControllers.MiV_CoreLevelInterruptor  @ sysbus 0x02000000

--- a/platforms/cpus/miv_rv32.repl
+++ b/platforms/cpus/miv_rv32.repl
@@ -4,7 +4,7 @@ cpu: CPU.RiscV32 @ sysbus
     timeProvider: clint
 
 tcm: Memory.MappedMemory @ sysbus 0x40000000
-    size: 0x400000
+    size: 0x40000
 
 // Power/Reset/Clock/Interrupt
 clint: IRQControllers.MiV_CoreLevelInterruptor  @ sysbus 0x02000000


### PR DESCRIPTION
The TCM is much smaller than the DDR used to be on the older platform. Maximum for TCM is 256KB.