### PR TITLE
Add robot test and CPU definitions for STM32F0_CRC peripheral

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/Infrastructure"]
 	path = src/Infrastructure
-	url = https://github.com/renode/renode-infrastructure.git
+	url = https://github.com/Pagten/renode-infrastructure.git
 [submodule "lib/termsharp"]
 	path = lib/termsharp
 	url = https://github.com/antmicro/termsharp.git

--- a/platforms/cpus/stm32f042.repl
+++ b/platforms/cpus/stm32f042.repl
@@ -1,0 +1,10 @@
+using "platforms/cpus/stm32f0.repl"
+
+flash: Memory.MappedMemory @ sysbus 0x08000000
+    size: 0x18000
+
+sram: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x1800
+
+crc: CRC.STM32F0_CRC @ sysbus 0x40023000
+    configurablePoly: false

--- a/platforms/cpus/stm32f072.repl
+++ b/platforms/cpus/stm32f072.repl
@@ -6,3 +6,5 @@ flash: Memory.MappedMemory @ sysbus 0x08000000
 sram: Memory.MappedMemory @ sysbus 0x20000000
     size: 0x4000
 
+crc: CRC.STM32F0_CRC @ sysbus 0x40023000
+    configurablePoly: true

--- a/tests/platforms/STM32F072b.robot
+++ b/tests/platforms/STM32F072b.robot
@@ -87,3 +87,12 @@ Should Read ADC
     Execute Command          sysbus.adc SetDefaultValue 1200
     Wait For Line On Uart    ADC reading: 1489
 
+Should Run stm32f0-crc-test Application
+    Execute Command          mach create
+    Execute Command          machine LoadPlatformDescription @platforms/boards/stm32f072b_discovery.repl
+    Execute Command          sysbus LoadELF @https://github.com/Pagten/stm32f0-crc-test/releases/download/v1.0.0/stm32f0-crc-test
+    Create Terminal Tester   ${UART}
+
+    Start Emulation
+
+    Wait For Line On Uart    test result: ok. 840 passed; 0 failed


### PR DESCRIPTION
This PR accompanies https://github.com/renode/renode-infrastructure/pull/69. It adds a robot test for the STM32F0_CRC peripheral contributed in that PR. It also adds an instance of the peripheral to the stm32f072 CPU and defines a new stm32f042 CPU that has this peripheral as well.

This PR can't be merged as-is, because it points the Infrastructure submodule to my own fork on GitHub. The robot test is also pointing to a binary on my own [stm32f0-crc-test](https://github.com/Pagten/stm32f0-crc-test) page on GitHub. The submodule can probably switch to the proper repo once the Infrastructure PR gets merged. The test binary should probably be hosted at https://dl.antmicro.com/projects/renode like the other test binaries. Please advise on the right approach here.