### PR TITLE
More portable MSBuild calls to allow builds for MinGW

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -186,11 +186,10 @@ else
       PROP_FILE="$CURRENT_PATH/src/Infrastructure/src/Emulator/Cores/windows-properties.csproj"
     fi
 fi
+
 cp "$PROP_FILE" "$OUTPUT_DIRECTORY/properties.csproj"
-
 # Build CCTask in Release configuration
-$CS_COMPILER /p:Configuration=Release "`get_path \"$ROOT_PATH/lib/cctask/CCTask.sln\"`" > /dev/null
-
+$CS_COMPILER -p:Configuration=Release "`get_path \"$ROOT_PATH/lib/cctask/CCTask.sln\"`" > /dev/null
 # clean instead of building
 if $CLEAN
 then
@@ -211,7 +210,7 @@ pushd "$ROOT_PATH/tools/building" > /dev/null
 ./check_weak_implementations.sh
 popd > /dev/null
 
-PARAMS+=(/p:Configuration=${CONFIGURATION}${BUILD_TARGET} /p:GenerateFullPaths=true)
+PARAMS+=(-p:Configuration=${CONFIGURATION}${BUILD_TARGET} -p:GenerateFullPaths=true)
 
 # build
 $CS_COMPILER "${PARAMS[@]}" "$TARGET"

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -22,7 +22,7 @@ else
     ON_WINDOWS=true
     ON_OSX=false
     ON_LINUX=false
-    CS_COMPILER=msbuild.exe
+    CS_COMPILER=MSBuild.exe
     LAUNCHER=""
     PYTHON_RUNNER="py -3"
 fi

--- a/tools/packaging/make_windows_packages.sh
+++ b/tools/packaging/make_windows_packages.sh
@@ -38,7 +38,7 @@ EOL
 
 mkdir -p $OUTPUT
 
-MSBuild.exe /t:Clean,Build windows/RenodeSetup/SetupProject.wixproj /p:version=${VERSION%\+*} /p:installer_name=$DIR
+MSBuild.exe -t:Clean,Build windows/RenodeSetup/SetupProject.wixproj -p:version=${VERSION%\+*} -p:installer_name=$DIR
 
 ### create windows package
 if $REMOVE_WORKDIR


### PR DESCRIPTION
More accurate MSBuild calling that allows to build Renode under MinGW (MinGW64). The mix of Cygwin and native Python not needed anymore, although still possible