### PR TITLE
bugfix: Updates to GPIOConnector

### DIFF
--- a/src/Renode/Connectors/GPIOConnector.cs
+++ b/src/Renode/Connectors/GPIOConnector.cs
@@ -62,15 +62,7 @@ namespace Antmicro.Renode.Connectors
             {
                 throw new RecoverableException("Peripheral {0} has no GPIO with number: {1}".FormatWith(source, pinNumber));
             }
-            if(sourcePin != null)
-            {
-                sourcePin.Disconnect();
-            }
             sourcePin = tempPin ?? throw new RecoverableException("Source PIN cannot be selected.");
-            if(sourcePin.IsConnected)
-            {
-                this.Log(LogLevel.Warning, "Overwriting source PIN connection.");
-            }
             sourcePin.Connect(this, 0);
         }
 


### PR DESCRIPTION
### Related issue

Issue detailed in #390.

### Description

The SelectSourcePin method incorrectly checked the source GPIO pin for connections and, if any were present, called source.Disconnect.  This would remove all previously connected targets from the source GPIO when all that is needed is that the GPIOConnector should be added as a target.

