### PR TITLE
[FIX] renode-test - added fail code and exit when python libraries are not installed

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -43,3 +43,4 @@ try:
 
 except ImportError as e:
     print("{}\nPlease install required dependencies with `pip install -r {}`".format(str(e), os.path.abspath(requirements)), file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
### Related issue
I did not take the time to describe the issue as I did figure out quite quickly how to solve it.

### Description
The PR fixes the run-test script so that it will return a fail code when there are missing python libraries. This is useful if someone is developing tests with this and is running in a docker container that needs an update (such I happen to do for Contiki-NG).

### Usage example
I did make use of the exit code of renode-test - but since the run-test script used by renote-test did not fail when libraries are missing all seemed ok (but was not). This is a quite an uncommon case to get hit by but test renode-test command and check the failure code when a library is missing - and it will return 0 (indicating all ok).
