### PR TITLE
[#455]Verilator Integration: Fix Limit Buffer in VerilatedPeripheral

### DIFF
--- a/src/Plugins/VerilatorPlugin/Verilated/Peripherals/VerilatedPeripheral.cs
+++ b/src/Plugins/VerilatorPlugin/Verilated/Peripherals/VerilatedPeripheral.cs
@@ -29,7 +29,7 @@ namespace Antmicro.Renode.Peripherals.Verilated
             this.OnReceive = HandleReceivedMessage;
             this.maxWidth = maxWidth;
 
-            timer = new LimitTimer(machine.ClockSource, frequency, this, LimitTimerName, limitBuffer, enabled: false, eventEnabled: true, autoUpdate: true);
+            timer = new LimitTimer(machine.ClockSource, frequency, this, LimitTimerName, limitBuffer, enabled: true, eventEnabled: true, autoUpdate: true);
             timer.LimitReached += () =>
             {
                 if(!verilatorConnection.TrySendMessage(new ProtocolMessage(ActionType.TickClock, 0, limitBuffer)))
@@ -40,8 +40,6 @@ namespace Antmicro.Renode.Peripherals.Verilated
                 allTicksProcessedARE.WaitOne();
                 this.NoisyLog("Tick: Verilated peripheral finished evaluating the model.");
             };
-
-            timer.Enabled = true;
 
             var innerConnections = new Dictionary<int, IGPIO>();
             for(int i = 0; i < numberOfInterrupts; i++)


### PR DESCRIPTION
Although the Enabled flag of the LimitTimer is set to True in the constructor, the default value is 'false'.  This means that every time a Reset is invoked, then the LimitTimer stops and there is no way to restart it.

Added Enabled=true in the Reset function to fix the issue.

Please note that all contributions to Renode require you to sign a [Contributor License Agreement](https://cla-assistant.io/renode/renode).

### Related issue

#455

https://github.com/renode/renode/issues/455

### Description

Bug: Although the Enabled flag of the LimitTimer is set to 'true' in the constructor of VerilatedPeripheral.cs, the default value is 'false'. This means that every time a Reset is invoked, then the LimitTimer stops and there is no way to restart it.

### Usage example

https://github.com/econnellmc/renode-issue-reproduction-template

Apologies for not setting up the full Robot framework, but I hope this is sufficient to show the problem.

I have made this example project based on the Microchip Icicle Kit mpfs-timer example:
https://github.com/polarfire-soc/polarfire-soc-bare-metal-examples/tree/main/driver-examples/mss/mss-timer/mpfs-timer-example

mpfs-timer-example.elf is the built artifact from this project when targeting LIM memory
Vtop is created by running the mpfs-timer Verilog source through Verilator (sim_main and Cmake files also provided)
The scripts and Platform files are from the Renode source, but I have added changes for the Verilated mstimer and some commands for initialising the analysers instead of launching GDB

Steps to reproduce in command.txt:

```
Run Renode, the > commands are for the Monitor

> start @test.resc 

Type '1' in the mmuart1 window.
mmuart2 window starts to report timed interrupts.

> sysbus.mstimer Reset

mmuart2 stops.
Typing a number in mmuart1 restarts or switches the test, but no further interrupts occur.

```

I built Renode commit 241bcbed (master as of 26/04/2023) and checked that it is still failing.
I built Renode commit 5b78348 (on my forked repo) and checked that the timer still works after the reset.