### PR TITLE
Verilator Integration: Define a  UART peripheral based on TI 16550 part

### DIFF
--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/peripherals/uart.h
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/peripherals/uart.h
@@ -26,9 +26,9 @@ struct UART : RenodeAgent
     uint32_t tx_reg_addr;
     uint8_t prev_irq;
 
-    private:
+    protected:
     void writeToBus(int width, uint64_t addr, uint64_t value) override;
     void handleCustomRequestType(Protocol* message) override;
-    void Txd();
-    void Rxd(uint8_t value);
+    virtual void Txd();
+    virtual void Rxd(uint8_t value);
 };


### PR DESCRIPTION
Texas Instruments 16550 UART shares register address 0x00 between the Transmit register and Divisor Latch.  This causes problems for the base Verilator Integration Library UART code which expects to see serial data following any write to reg 0x00.
Related issue
https://github.com/renode/renode/issues/475

Description
Add a component to the VerilatorIntegrationLibrary that supports UARTs based on the TI 16550 design. The existing UART handler throws an exception due to a difference in how the registers are used in the 16550 design.

I created a UART_16550 class that inherits most of it's functionality from the UART class, but it overrides the write methods that differ in the 16550 part.

This approach should mean that any existing UARTs will not be effected by my changes.

Usage example
https://github.com/econnellmc/renode-issue-reproduction-template/tree/475-UART_fail

https://github.com/econnellmc/renode-issue-reproduction-template/tree/475-UART_pass

I'm not sure how useful this example is. I cannot currently share the verilog code that is being compiled into the Vtop executables, so I have had to commit the built binaries. The difference between the two Vtop is in the Sim_main.cpp, where one of them uses the existing UART class and fails. The other uses the UART_16550 class and passes.

Additional information
I need some assistance to get the Robot scripts working correctly. I got it working locally by running Renode portable which was copied to the local directory. However, this doesn't gel with the way the github workflow works.

Very happy to make changes based on feedback if there is a different way you'd prefer this to be done.