### PR TITLE
Harmonize LibraryVerilatorConnection with SocketVerilatorConnection [BugFix]

### DIFF
--- a/src/Plugins/VerilatorPlugin/Connection/LibraryVerilatorConnection.cs
+++ b/src/Plugins/VerilatorPlugin/Connection/LibraryVerilatorConnection.cs
@@ -78,7 +78,7 @@ namespace Antmicro.Renode.Plugins.VerilatorPlugin.Connection
 
         public void Connect()
         {
-            // intentionally left empty
+            IsConnected = true;
         }
 
         public void HandleMessage()
@@ -177,7 +177,6 @@ namespace Antmicro.Renode.Plugins.VerilatorPlugin.Connection
                         initializeNative();
                         mainResponsePointer = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(ProtocolMessage)));
                         senderResponsePointer = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(ProtocolMessage)));
-                        IsConnected = true;
                         resetPeripheral();
                     }
                     catch(Exception e)

--- a/src/Plugins/VerilatorPlugin/Verilated/Peripherals/CFUVerilatedPeripheral.cs
+++ b/src/Plugins/VerilatorPlugin/Verilated/Peripherals/CFUVerilatedPeripheral.cs
@@ -152,6 +152,7 @@ namespace Antmicro.Renode.Peripherals.Verilated
                         errorPointer = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(int)));
                         executeBinder = new NativeBinder(this, value);
                         verilatedPeripheral.SimulationFilePath = value;
+                        verilatedPeripheral.Connect();
 
                         if(timer != null)
                         {


### PR DESCRIPTION
### Related issue

None created

### Description
A warning is unconditionally displayed whenever using a `LibraryVerilatorConnection`.

> The Verilated peripheral is already connected.

The warning is generated here:

https://github.com/renode/renode/blob/cd1aa99b7210730429d2e4c1f68063418ba2c58b/src/Plugins/VerilatorPlugin/Verilated/Peripherals/BaseVerilatedPeripheral.cs#L52-L60

After setting the `BaseVerilatedPeripheral.SimulationFilePath`, `BaseVerilatedPeripheralConnect()` then called, I supposed this is required for sockets but not for libraries.

https://github.com/renode/renode/blob/cd1aa99b7210730429d2e4c1f68063418ba2c58b/src/Plugins/VerilatorPlugin/Verilated/Peripherals/BaseVerilatedPeripheral.cs#L176-L200

The mitigatigation I am suggesting:
Make `LibraryVerilatorConnection.IsConnected` return `false` until `LibraryVerilatorConnection.Connect()` is called.

This make the warning display if and only if `*VerilatedPeripheral.Connect()` is truly called after it is already connected.

`CfuVerilatedPeripheral.SimulationFilePath` differed from `BaseVerilatedPeripheral.SimulationFilePath` by not calling `CfuVerilatedPeripheral.Connect()`  in the setter. I updated this also to prevent regression and probably also fixes Socket connections for Cfu style peripherals.

