### PR TITLE
Initial xG24 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ packages
 #verilator trace files
 *.vcd
 
+.DS_Store
 perf.data
 perf.script

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/Infrastructure"]
 	path = src/Infrastructure
-	url = https://github.com/renode/renode-infrastructure.git
+	url = https://github.com/SiliconLabs/renode-infrastructure.git 
 [submodule "lib/termsharp"]
 	path = lib/termsharp
 	url = https://github.com/antmicro/termsharp.git
@@ -37,4 +37,4 @@
 	branch = renode-build
 [submodule "lib/bc-csharp"]
 	path = lib/bc-csharp
-	url = https://github.com/antmicro/bc-csharp.git
+	url = https://github.com/antmicro/bc-csharp.git 

--- a/platforms/boards/silabs/brd4186c.repl
+++ b/platforms/boards/silabs/brd4186c.repl
@@ -1,0 +1,10 @@
+using "platforms/cpus/silabs/efr32s2/efr32mg24.repl"
+
+led0: Miscellaneous.LED @ gpioPort 66
+led1: Miscellaneous.LED @ gpioPort 67
+
+button0: Miscellaneous.Button @ gpioPort 64
+button1: Miscellaneous.Button @ gpioPort 65
+
+deviceInformation:
+    deviceNumber: 332

--- a/platforms/cpus/silabs/efr32s2/efr32mg24.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32mg24.repl
@@ -1,0 +1,331 @@
+i2c0: I2C.EFR32_I2CController @ sysbus <0x5B000000, +0x4000>
+    -> nvic@27
+
+usart0: UART.EFR32xG22_USART @ sysbus <0x5005C000, +0x4000>
+    ReceiveIRQ -> nvic@9
+    TransmitIRQ -> nvic@10
+    RxDataAvailableRequest -> ldma@0x0040
+    RxDataAvailableSingleRequest -> ldma@0x1040
+    TxBufferLowRequest -> ldma@0x0042
+    TxBufferLowSingleRequest -> ldma@0x1042
+    TxEmptyRequest -> ldma@0x0044
+
+radio: Wireless.EFR32xG24_Radio @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40098000; size: 0x4000; region: "hostmailbox" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50098000; size: 0x4000; region: "hostmailbox_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA8004000; size: 0x4000; region: "frc" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA800C000; size: 0x4000; region: "agc" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA8010000; size: 0x4000; region: "crc" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA8014000; size: 0x4000; region: "modem" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA8018000; size: 0x4000; region: "synth" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA801C000; size: 0x4000; region: "protimer" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA8020000; size: 0x4000; region: "rac" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA802C000; size: 0x4000; region: "rfmailbox" };
+        sysbus new Bus.BusMultiRegistration { address: 0xAA000000; size: 0x4000; region: "bufc" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB8004000; size: 0x4000; region: "frc_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB800C000; size: 0x4000; region: "agc_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB8010000; size: 0x4000; region: "crc_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB8014000; size: 0x4000; region: "modem_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB8018000; size: 0x4000; region: "synth_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB801C000; size: 0x4000; region: "protimer_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB8020000; size: 0x4000; region: "rac_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB802C000; size: 0x4000; region: "rfmailbox_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xBA000000; size: 0x4000; region: "bufc_ns" }
+    }
+    ram: sram
+    sequencer: seqcpu
+    // Main CPU interrupts
+    AutomaticGainControlIRQ -> nvic@30
+    BufferControllerIRQ -> nvic@31
+    FrameControllerPrioritizedIRQ -> nvic@32
+    FrameControllerIRQ -> nvic@33
+    ModulatorAndDemodulatorIRQ -> nvic@34
+    ProtocolTimerIRQ -> nvic@35
+    RadioControllerRadioStateMachineIRQ -> nvic@36
+    RadioControllerSequencerIRQ -> nvic@37
+    HostMailboxIRQ -> nvic@38
+    SynthesizerIRQ -> nvic@39
+    // Sequencer CPU interrupts
+    SeqOffIRQ ->seqnvic@0
+    SeqRxWarmIRQ ->seqnvic@1
+    SeqRxSearchIRQ ->seqnvic@2
+    SeqRxFrameIRQ ->seqnvic@3
+    SeqRxPoweringDownIRQ ->seqnvic@4
+    SeqRx2RxIRQ ->seqnvic@5
+    SeqRxOverflowIRQ ->seqnvic@6
+    SeqRx2TxIRQ ->seqnvic@7
+    SeqTxWarmIRQ ->seqnvic@8
+    SeqTxIRQ ->seqnvic@9
+    SeqTxPoweringDownIRQ ->seqnvic@10
+    SeqTx2RxIRQ ->seqnvic@11
+    SeqTx2TxIRQ ->seqnvic@12
+    SeqShutdownIRQ ->seqnvic@13
+    SeqRadioControllerIRQ ->seqnvic@14
+    SeqFrameControllerIRQ ->seqnvic@15
+    SeqFrameControllerPriorityIRQ ->seqnvic@16
+    SeqModulatorAndDemodulatorIRQ ->seqnvic@17
+    SeqBufferControllerIRQ ->seqnvic@18
+    SeqAutomaticGainControlIRQ ->seqnvic@19
+    SeqProtocolTimerIRQ -> seqnvic@20
+    SeqSynthesizerIRQ -> seqnvic@22
+    SeqRfMailboxIRQ -> seqnvic@23
+
+msc: Silabs.MSC_3 @ sysbus <0x50030000, +0x4000>
+    cpu: cpu
+    IRQ -> nvic@50
+
+gpioPort: GPIOPort.EFR32xg24_GPIOPort @ sysbus <0x5003C000, +0x4000>
+    EvenIRQ -> nvic@26
+    OddIRQ -> nvic@25
+
+bitclear: Miscellaneous.BitAccess
+    address: 0x2000
+    mode: BitAccessMode.Clear
+
+bitset: Miscellaneous.BitAccess
+    address: 0x1000
+    mode: BitAccessMode.Set
+
+sram: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x40000
+
+seqram: Memory.MappedMemory @ {
+        sysbus 0xB0000000;
+
+        sysbus new Bus.BusPointRegistration {
+            address: 0x0;
+            cpu: seqcpu
+        }
+    }
+    size: 0x4000
+
+frcram: Memory.MappedMemory @ {
+        sysbus 0xB0004000;
+
+        sysbus new Bus.BusPointRegistration {
+            address: 0x00004000;
+            cpu: seqcpu
+        }
+    }
+    size: 0x1000
+
+nvic: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
+        address: 0xE000E000;
+        cpu: cpu
+    }
+    -> cpu@0
+
+seqnvic: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
+        address: 0xE000E000;
+        cpu: seqcpu
+    }
+    -> seqcpu@0
+
+cpu: CPU.CortexM @ sysbus
+    nvic: nvic
+    cpuType: "cortex-m33"
+    id: 0
+
+seqcpu: CPU.CortexM @ sysbus
+    nvic: seqnvic
+    cpuType: "cortex-m0+"
+    id: 1
+    IsHalted: true
+
+timer0: Timers.EFR32_Timer @ sysbus <0x50048000, +0x4000>
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@4
+
+timer1: Timers.EFR32_Timer @ sysbus <0x5004C000, +0x4000>
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@5
+
+ldma: DMA.EFR32MG24_LDMA @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x50040000; size: 0x4000; region: "ldma" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50044000; size: 0x4000; region: "ldmaxbar" }
+    }
+    -> nvic@21
+
+wtimer0: Timers.EFR32_Timer @ sysbus <0x5B004000, +0x4000>
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit32
+    -> nvic@42
+
+wtimer1: Timers.EFR32_Timer @ sysbus <0x5B008000, +0x4000>
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit32
+    -> nvic@43
+
+deviceInformation: SiLabs.EFR32xG24DeviceInformation @ sysbus 0x0FE08000
+    deviceFamily: DeviceFamily.EFR32MG24
+    deviceNumber: 0x1
+    flashDevice: flash
+    sramDevice: sram
+
+DCDC_IF: Python.PythonPeripheral @ sysbus 0x50094028
+    size: 0x4
+    initable: true
+    script: "request.value = 0xffffffff"
+
+flash: Memory.MappedMemory @ sysbus 0x08000000
+    size: 0x200000
+
+flashspi: SPI.Macronix_MX25R
+    underlyingMemory: flash
+
+cmu: Silabs.Cmu_3 @ sysbus 0x50008000
+
+lfxo: Silabs.Lfxo_1 @ sysbus 0x50020000
+
+hfrco0: Silabs.Hfrco_2 @ sysbus 0x50010000
+
+dpll: Silabs.Dpll_1 @ sysbus 0x5001C000
+
+lfrco: Silabs.Lfrco_2 @ sysbus 0x50024000
+
+hfxo: Silabs.Hfxo_3 @ sysbus 0x5A004000
+
+hfrco1: Silabs.Hfrco_2 @ sysbus 0x5A000000
+
+emu: Silabs.Emu_3 @ sysbus 0x50004000
+
+syscfg: Silabs.Syscfg_3 @ sysbus 0x5007C000
+
+sysrtc: Silabs.Sysrtc_1 @ sysbus 0x500a8000
+    frequency: 32768
+    IRQ -> nvic@67
+
+semailbox: Silabs.SecureEngineMailbox_1 @ sysbus <0x4C000000, +0x7F>
+    RxIRQ -> nvic@65
+    TxIRQ -> nvic@66
+
+flashuserdata: Silabs.EFR32xG24_FlashUserData @ sysbus <0x0FE00000, +0xA>
+
+sysbus:
+    init add:
+        Tag <0x40000000, 0x40003FFF> "SCRATCHPAD_S"
+        Tag <0x40004000, 0x40007FFF> "EMU_S"
+        Tag <0x40008000, 0x4000BFFF> "CMU_S"
+        Tag <0x40010000, 0x40013FFF> "HFRCO0_S"
+        Tag <0x40018000, 0x4001BFFF> "FSRCO_S"
+        Tag <0x4001C000, 0x4001FFFF> "DPLL0_S"
+        Tag <0x40020000, 0x40023FFF> "LFXO_S"
+        Tag <0x40024000, 0x40027FFF> "LFRCO_S"
+        Tag <0x40028000, 0x4002BFFF> "ULFRCO_S"
+        Tag <0x40030000, 0x40033FFF> "MSC_S"
+        Tag <0x40034000, 0x40037FFF> "ICACHE0_S"
+        Tag <0x40038000, 0x4003BFFF> "PRS_S"
+        Tag <0x4003C000, 0x4003FFFF> "GPIO_S"
+        Tag <0x40040000, 0x40043FFF> "LDMA_S"
+        Tag <0x40044000, 0x40047FFF> "LDMAXBAR_S"
+        Tag <0x40048000, 0x4004BFFF> "TIMER0_S"
+        Tag <0x4004C000, 0x4004FFFF> "TIMER1_S"
+        Tag <0x40050000, 0x40053FFF> "TIMER2_S"
+        Tag <0x40054000, 0x40057FFF> "TIMER3_S"
+        Tag <0x40058000, 0x4005BFFF> "TIMER4_S"
+        Tag <0x4005C000, 0x4005FFFF> "USART0_S"
+        Tag <0x40064000, 0x40067FFF> "BURTC_S"
+        Tag <0x40068000, 0x4006BFFF> "I2C1_S"
+        Tag <0x40078000, 0x4007BFFF> "SYSCFG_S_CFGNS"
+        Tag <0x4007C000, 0x4007FFFF> "SYSCFG_S"
+        Tag <0x40080000, 0x40083FFF> "BURAM_S"
+        Tag <0x40088000, 0x4008BFFF> "GPCRC_S"
+        Tag <0x40094000, 0x40097FFF> "DCDC_S"
+        Tag <0x40098000, 0x4009BFFF> "HOSTMAILBOX_S"
+        Tag <0x400A0000, 0x400A3FFF> "EUSART1_S"
+        Tag <0x400A8000, 0x400ABFFF> "SYSRTC0_S"
+        Tag <0x400B0000, 0x400B3FFF> "KEYSCAN_S"
+        Tag <0x400B4000, 0x400B7FFF> "DMEM_S"
+        Tag <0x44000000, 0x44003FFF> "RADIOAES_S"
+        Tag <0x44008000, 0x4400BFFF> "SMU_S"
+        Tag <0x4400C000, 0x4400FFFF> "SMU_S_CFGNS"
+        Tag <0x49000000, 0x49003FFF> "LETIMER0_S"
+        Tag <0x49004000, 0x49007FFF> "IADC0_S"
+        Tag <0x49008000, 0x4900BFFF> "ACMP0_S"
+        Tag <0x4900C000, 0x4900FFFF> "ACMP1_S"
+        Tag <0x49024000, 0x49027FFF> "VDAC0_S"
+        Tag <0x49028000, 0x4902BFFF> "VDAC1_S"
+        Tag <0x49030000, 0x49033FFF> "PCNT0_S"
+        Tag <0x4A000000, 0x4A003FFF> "HFRCOEM23_S"
+        Tag <0x4A004000, 0x4A007FFF> "HFXO0_S"
+        Tag <0x4B000000, 0x4B003FFF> "I2C0_S"
+        Tag <0x4B004000, 0x4B007FFF> "WDOG0_S"
+        Tag <0x4B008000, 0x4B00BFFF> "WDOG1_S"
+        Tag <0x4B010000, 0x4B013FFF> "EUSART0_S"
+        Tag <0x4C000000, 0x4C003FFF> "SEMAILBOX_S_HOST"
+        Tag <0x4D000000, 0x4D003FFF> "MVP_S"
+        Tag <0x50000000, 0x50003FFF> "SCRATCHPAD_NS"
+        Tag <0x50004000, 0x50007FFF> "EMU_NS"
+        Tag <0x50008000, 0x5000BFFF> "CMU_NS"
+        Tag <0x50010000, 0x50013FFF> "HFRCO0_NS"
+        Tag <0x50018000, 0x5001BFFF> "FSRCO_NS"
+        Tag <0x5001C000, 0x5001FFFF> "DPLL0_NS"
+        Tag <0x50020000, 0x50023FFF> "LFXO_NS"
+        Tag <0x50024000, 0x50027FFF> "LFRCO_NS"
+        Tag <0x50028000, 0x5002BFFF> "ULFRCO_NS"
+        Tag <0x50030000, 0x50033FFF> "MSC_NS"
+        Tag <0x50034000, 0x50037FFF> "ICACHE0_NS"
+        Tag <0x50038000, 0x5003BFFF> "PRS_NS"
+        Tag <0x5003C000, 0x5003FFFF> "GPIO_NS"
+        Tag <0x50040000, 0x50043FFF> "LDMA_NS"
+        Tag <0x50044000, 0x50047FFF> "LDMAXBAR_NS"
+        Tag <0x50048000, 0x5004BFFF> "TIMER0_NS"
+        Tag <0x5004C000, 0x5004FFFF> "TIMER1_NS"
+        Tag <0x50050000, 0x50053FFF> "TIMER2_NS"
+        Tag <0x50054000, 0x50057FFF> "TIMER3_NS"
+        Tag <0x50058000, 0x5005BFFF> "TIMER4_NS"
+        Tag <0x5005C000, 0x5005FFFF> "USART0_NS"
+        Tag <0x50064000, 0x50067FFF> "BURTC_NS"
+        Tag <0x50068000, 0x5006BFFF> "I2C1_NS"
+        Tag <0x50078000, 0x5007BFFF> "SYSCFG_NS_CFGNS"
+        Tag <0x5007C000, 0x5007FFFF> "SYSCFG_NS"
+        Tag <0x50080000, 0x50083FFF> "BURAM_NS"
+        Tag <0x50088000, 0x5008BFFF> "GPCRC_NS"
+        Tag <0x50094000, 0x50097FFF> "DCDC_NS"
+        Tag <0x50098000, 0x5009BFFF> "HOSTMAILBOX_NS"
+        Tag <0x500A0000, 0x500A3FFF> "EUSART1_NS"
+        Tag <0x500A8000, 0x500ABFFF> "SYSRTC0_NS"
+        Tag <0x500B0000, 0x500B3FFF> "KEYSCAN_NS"
+        Tag <0x500B4000, 0x500B7FFF> "DMEM_NS"
+        Tag <0x54000000, 0x54003FFF> "RADIOAES_NS"
+        Tag <0x54008000, 0x5400BFFF> "SMU_NS"
+        Tag <0x5400C000, 0x5400FFFF> "SMU_NS_CFGNS"
+        Tag <0x59000000, 0x59003FFF> "LETIMER0_NS"
+        Tag <0x59004000, 0x59007FFF> "IADC0_NS"
+        Tag <0x59008000, 0x5900BFFF> "ACMP0_NS"
+        Tag <0x5900C000, 0x5900FFFF> "ACMP1_NS"
+        Tag <0x59024000, 0x59027FFF> "VDAC0_NS"
+        Tag <0x59028000, 0x5902BFFF> "VDAC1_NS"
+        Tag <0x59030000, 0x59033FFF> "PCNT0_NS"
+        Tag <0x5A000000, 0x5A003FFF> "HFRCOEM23_NS"
+        Tag <0x5A004000, 0x5A007FFF> "HFXO0_NS"
+        Tag <0x5B000000, 0x5B003FFF> "I2C0_NS"
+        Tag <0x5B004000, 0x5B007FFF> "WDOG0_NS"
+        Tag <0x5B008000, 0x5B00BFFF> "WDOG1_NS"
+        Tag <0x5B010000, 0x5B013FFF> "EUSART0_NS"
+        Tag <0x5C000000, 0x5C003FFF> "SEMAILBOX_NS_HOST"
+        Tag <0x5D000000, 0x5D003FFF> "MVP_NS"
+        Tag <0x54000000, 0x540007FF> "RADIOAES_NS"
+        Tag <0x5C000000, 0x5C00007F> "SEMAILBOX_NS"
+        Tag <0xA8004000, 0xA8007FFF> "FRC"
+        Tag <0xA800C000, 0xA800FFFF> "AGC"
+        Tag <0xA8010000, 0xA8013FFF> "CRC"
+        Tag <0xA8014000, 0xA8017FFF> "MODEM"
+        Tag <0xA8018000, 0xA801BFFF> "SYNTH"
+        Tag <0xA801C000, 0xA801FFFF> "PROTIMER"
+        Tag <0xA8020000, 0xA8023FFF> "RAC"
+        Tag <0xA802C000, 0xA802FFFF> "RFMAILBOX"
+        Tag <0xAA000000, 0xAA003FFF> "BUFC"
+        Tag <0xB8004000, 0xB8007FFF> "FRC_NS"
+        Tag <0xB800C000, 0xB800FFFF> "AGC_NS"
+        Tag <0xB8010000, 0xB8003FFF> "CRC_NS"
+        Tag <0xB8014000, 0xB8017FFF> "MODEM_NS"
+        Tag <0xB8018000, 0xB801BFFF> "SYNTH_NS"
+        Tag <0xB801C000, 0xB801FFFF> "PROTIMER_NS"
+        Tag <0xB8020000, 0xB8023FFF> "RAC_NS"
+        Tag <0xB802C000, 0xB802FFFF> "RFMAILBOX_NS"
+        Tag <0xBA000000, 0xBA003FFF> "BUFC_NS"
+        Tag <0xE0000000, 0xE0000FFF> "ITM"
+        Tag <0x0FE00000, 0x0FE00009> "FLASH_USER_DATA"

--- a/scripts/multi-node/silabs/efr32xg24/twonode_demo.resc
+++ b/scripts/multi-node/silabs/efr32xg24/twonode_demo.resc
@@ -1,0 +1,50 @@
+include @src/Infrastructure/src/Emulator/Peripherals/Peripherals/Wireless/EFR32xG24_Radio.cs
+
+:name: TWONODE-DEMO
+:description: This script runs the configured application on BRD4186C in a two-node setup.
+
+# Change this to the actual location of the application to run
+set bin $ORIGIN/rail_soc_railtest.out
+
+using sysbus
+emulation CreateIEEE802_15_4Medium "wireless"
+
+# Start wireshark
+#emulation LogIEEE802_15_4Traffic
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+
+################################################
+# Create node1
+################################################
+mach create "node1"
+machine LoadPlatformDescription "platforms/boards/silabs/brd4186c.repl"
+runMacro $reset
+emulation CreateServerSocketTerminal 3451 "cli_node1"
+connector Connect sysbus.usart0 cli_node1
+connector Connect sysbus.radio wireless
+### Debug
+# Uncomment to enable debugging of main CPU
+#machine StartGdbServer 3333 false cpu
+# Uncomment to enable debugging of Sequencer CPU
+#machine StartGdbServer 3333 false seqcpu
+
+mach clear
+
+################################################
+# Create node2
+################################################
+mach create "node2"
+machine LoadPlatformDescription "platforms/boards/silabs/brd4186c.repl"
+runMacro $reset
+emulation CreateServerSocketTerminal 3452 "cli_node2"
+connector Connect sysbus.usart0 cli_node2
+connector Connect sysbus.radio wireless
+### Debug
+# Uncomment to enable debugging of main CPU
+#machine StartGdbServer 3333 false cpu
+# Uncomment to enable debugging of Sequencer CPU
+#machine StartGdbServer 3333 false seqcpu

--- a/src/Renode/Renode_NET.csproj
+++ b/src/Renode/Renode_NET.csproj
@@ -9,6 +9,11 @@
     <StartupObject>Antmicro.Renode.Program</StartupObject>
     <AssemblyName>Renode</AssemblyName>
     <PropertiesLocation>..\..\output\properties.csproj</PropertiesLocation>
+    <PublishSingleFile>true</PublishSingleFile>
+    <UseAppHost>true</UseAppHost>
+    <IncludeNativeLibrariesInSingleFile>true</IncludeNativeLibrariesInSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
   <PropertyGroup Condition=" $(PORTABLE) == 'true' ">
     <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
Preliminary support for xG24 Silicon Labs platform.

- Radio model is being  pulled from the included twonode_demo.resc script because of some dependency issue with the CortexM class that prevents us from including this model in the Peripherals.csproj file
- efr32mg24.repl provides a functional Silicon Labs MG24 platform 