### PR TITLE
Add initial support for AHB protocol

### DIFF
--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_if.sv
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_if.sv
@@ -1,0 +1,63 @@
+//
+//  Copyright 2023 Renesas Electronics Corporation
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'LICENSE'.
+//
+
+interface renode_ahb_if #(
+    int unsigned ADDR_WIDTH = 32,
+    int unsigned DATA_WIDTH =32
+)(
+    input logic HCLK
+);
+    logic                     HRESETn;
+    logic [ADDR_WIDTH-1:0]    HADDR;
+    logic [DATA_WIDTH-1:0]    HWDATA;
+    logic [DATA_WIDTH-1:0]    HRDATA;
+    logic [3:0]               HBURST;
+    logic                     HWRITE;
+    logic [1:0]               HTRANS;
+    logic                     HRESP;
+    logic [2:0]               HSIZE;
+    logic [ADDR_WIDTH/8-1:0]  HWSTRB;
+    logic                     HSEL;
+    logic                     HREADY;
+    logic                     HGRANT;
+    logic                     HREADYOUT;
+
+    function static bit are_valid_bits_supported(renode_pkg::valid_bits_e valid_bits);
+        case (valid_bits)
+        renode_pkg::Byte: return DATA_WIDTH >= 8;
+        renode_pkg::Word: return DATA_WIDTH >= 16;
+        renode_pkg::DoubleWord: return DATA_WIDTH >= 32;
+        renode_pkg::QuadWord: return DATA_WIDTH >= 64;
+        default: return 0;
+        endcase
+    endfunction
+
+    function int determine_burst_length(logic [3:0] HBURST);
+        int burst_length;
+        case (HBURST)
+            4'b0000: burst_length = 1;  // SINGLE
+            4'b0001: burst_length = 1;  // INCR (undefined length, but we'll represent as 1 for simplicity)
+            4'b0010: burst_length = 4;  // WRAP4
+            4'b0011: burst_length = 4;  // INCR4
+            4'b0100: burst_length = 8;  // WRAP8
+            4'b0101: burst_length = 8;  // INCR8
+            4'b0110: burst_length = 16; // WRAP16
+            4'b0111: burst_length = 16; // INCR16
+            4'b1000: burst_length = 32; // WRAP32
+            4'b1001: burst_length = 32; // INCR32
+            4'b1010: burst_length = 64; // WRAP64
+            4'b1011: burst_length = 64; // INCR64
+            4'b1100: burst_length = 128;// WRAP128
+            4'b1101: burst_length = 128;// INCR128
+            4'b1110: burst_length = 256;// WRAP256
+            4'b1111: burst_length = 256;// INCR256
+            default: burst_length = 1;  // Default to SINGLE
+        endcase
+        return burst_length;
+    endfunction
+
+endinterface //ahb_if

--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_manager.sv
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_manager.sv
@@ -1,0 +1,116 @@
+//
+//  Copyright 2023 Renesas Electronics Corporation
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'LICENSE'.
+//
+
+module renode_ahb_manager (
+    renode_ahb_if bus,
+    input renode_pkg::bus_connection connection
+);
+    typedef logic [bus.ADDR_WIDTH-1:0] address_t;
+    typedef logic [bus.DATA_WIDTH-1:0] data_t;
+    wire clk = bus.HCLK;
+    logic ready_gen;
+
+    assign bus.HREADY = ready_gen;
+
+    //reset procedure
+    always @(connection.reset_assert_request) begin
+        bus.HTRANS = '0;
+        bus.HADDR = '0;
+        bus.HWRITE = '0;
+        bus.HBURST = '0;
+        bus.HSIZE = '0;
+        bus.HTRANS = '0;
+        ready_gen = 0;
+        bus.HRESETn = '0;
+        repeat (2) @(posedge clk);
+        connection.reset_assert_respond();
+    end
+
+    always @(connection.reset_deassert_request) begin
+        bus.HRESETn = 1;
+        // Wait for one or more clock edges to be sure that all modules aren't in a reset state.
+        repeat (2) @(posedge clk);
+        connection.reset_deassert_respond();
+    end
+
+    // Copy the readyout signal from the subordinate to the manager
+    always @(posedge clk) begin
+        if (bus.HREADYOUT) begin
+            ready_gen <= 1;
+        end
+        else begin
+            ready_gen <= 0;
+        end
+    end
+
+    always @(connection.read_transaction_request) read_transaction();
+    always @(connection.write_transaction_request) write_transaction();
+
+    function automatic bit check_response(logic response);
+        if (response) begin
+            connection.log_warning($sformatf("AHB manager: error response from subordinate"));
+            return 1;
+        end
+        else begin
+            connection.log_warning($sformatf("AHB manager: no error response"));
+            return 0;
+        end
+    endfunction
+
+    task static write_transaction();
+        address_t address;
+        data_t data;
+        bit is_error;
+        data = data_t'(connection.write_transaction_data);
+        address = address_t'(connection.write_transaction_address);
+        `ifdef RENODE_DEBUG
+        $display("AHB manager: write transaction started, at address %h, data %h", address, data);
+        `endif
+        @(posedge clk);
+        bus.HADDR = address;
+        bus.HWRITE = 1;
+        bus.HTRANS = 2;  // NONSEQ
+        bus.HBURST = '0; //configure for single burst
+        bus.HSIZE = 2;   //configure for 4 bytes
+        do @(posedge clk); while (!bus.HREADY);
+        bus.HWDATA = data;
+        bus.HTRANS = 0;
+        bus.HWRITE = 0;
+        bus.HSIZE = 0;
+        is_error = check_response(bus.HRESP);
+        connection.write_respond(is_error);
+    endtask
+
+    task static read_transaction();
+        bit is_error;
+        address_t address;
+        renode_pkg::valid_bits_e valid_bits;
+        data_t data;
+
+        address = address_t'(connection.read_transaction_address);
+        `ifdef RENODE_DEBUG
+        $display("AHB manager: read transaction from address %h", address);
+        `endif
+
+        @(posedge clk);
+        bus.HADDR = address;
+        bus.HWRITE = '0;
+        bus.HBURST = '0;
+        bus.HTRANS = 2;
+        bus.HSIZE = 2;
+        do @(posedge clk); while (!bus.HREADY);
+        data = bus.HRDATA;
+        bus.HTRANS = '0;
+        is_error = check_response(bus.HRESP);
+
+        `ifdef RENODE_DEBUG
+        $display("AHB manager: read data = %h", data);
+        `endif
+        connection.read_respond({32'b0,data}, is_error);
+    endtask
+
+endmodule

--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_manager.sv
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_manager.sv
@@ -97,6 +97,7 @@ module renode_ahb_manager (
         `endif
 
         @(posedge clk);
+        bus.HSEL = 1;
         bus.HADDR = address;
         bus.HWRITE = '0;
         bus.HBURST = '0;
@@ -106,6 +107,7 @@ module renode_ahb_manager (
         data = bus.HRDATA;
         bus.HTRANS = '0;
         is_error = check_response(bus.HRESP);
+        bus.HSEL = '0;
 
         `ifdef RENODE_DEBUG
         $display("AHB manager: read data = %h", data);

--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_subordinate.sv
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/hdl/modules/ahb/renode_ahb_subordinate.sv
@@ -1,0 +1,79 @@
+//
+//  Copyright 2023 Renesas Electronics Corporation
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'LICENSE'.
+//
+
+module renode_ahb_subordinate (
+    renode_ahb_if bus,
+    input renode_pkg::bus_connection connection
+);
+    typedef logic [bus.ADDR_WIDTH-1:0] address_t;
+    typedef logic [bus.DATA_WIDTH-1:0] data_t;
+    typedef logic [1:0] response_t;
+    wire clk = bus.HCLK;
+
+    always @(connection.reset_assert_request) begin
+        bus.HRESETn = 0;
+        bus.HREADYOUT = 0;
+        bus.HRESP = 0;
+        bus.HRDATA = 0;
+        bus.HSEL = 0;
+        repeat(2) @(posedge clk);
+        connection.reset_assert_respond();
+    end
+
+    always @(connection.reset_deassert_request) begin
+        bus.HRESETn = 1;
+        repeat (2) @(posedge clk);
+        connection.reset_deassert_respond();
+    end
+
+    always @(clk) read_transaction();
+    always @(clk) write_transaction();
+
+    task static read_transaction();
+        address_t address;
+        renode_pkg::data_t data;
+        bit is_error;
+        valid_bits_e valid_data;
+        valid_data = valid_bits_e'({32'b0,{32{1'b1}}});
+
+        bus.HSEL = 1;
+        bus.HREADYOUT = 1;
+        do @(posedge clk); while ((!bus.HREADY) | (bus.HTRANS != 2) | bus.HWRITE == 1);
+        address = bus.HADDR;
+        connection.read(renode_pkg::address_t'(address), valid_data, data, is_error);
+        if (is_error) connection.log_warning($sformatf("Unable to read data from Renode at address 'h%h", address));
+        `ifdef RENODE_DEBUG
+        $display("AHB subordinate: read transaction initiated at address %h, data = %h", address, data);
+        `endif
+        @(posedge clk)
+        bus.HRDATA = data;
+        bus.HRESP = is_error;
+        bus.HREADYOUT = 1;
+    endtask
+
+    task static write_transaction();
+        address_t address;
+        data_t data;
+        bit is_error;
+        valid_bits_e valid_data;
+        valid_data = valid_bits_e'({32'b0,{32{1'b1}}});
+
+        do @(posedge clk); while ((!bus.HREADY) | (bus.HTRANS != 2) | bus.HWRITE == 0);
+        address = bus.HADDR;
+        @(posedge clk)
+        data = bus.HWDATA;
+        `ifdef RENODE_DEBUG
+        $display("AHB subordinate: write transaction at addr %h, data = %h", address, data);
+        `endif
+
+        connection.write(renode_pkg::address_t'(address), valid_data,renode_pkg::data_t'(data) & valid_data, is_error);
+        if (is_error) connection.log_warning($sformatf("Unable to write data to Renode at address 'h%h", address));
+        bus.HRESP = is_error;
+        bus.HREADYOUT = 1;
+    endtask
+
+endmodule


### PR DESCRIPTION
This patch adds basic support for AHB protocol in Renode DPI interface. Currently, it supports only single (i.e., basic) transfers. Specifically, it enables NONSEQ 32-bit reads/writes. So, burst transfers, locking, etc. are not supported yet.