### PR TITLE
renode: follow symlinks correctly for ROOT_PATH

### DIFF
--- a/renode
+++ b/renode
@@ -2,8 +2,8 @@
 set -e
 set -u
 
-# this is to support running Renode from external directory
-ROOT_PATH="$(cd $(dirname $0); echo $PWD)"
+# this is to support running Renode from an external directory and via a symlink
+ROOT_PATH="$(cd $(dirname $(readlink -f $0 2>/dev/null || echo $0)); echo $PWD)"
 
 . "$ROOT_PATH/tools/common.sh"
 

--- a/renode-test
+++ b/renode-test
@@ -2,7 +2,8 @@
 set -e
 set -u
 
-ROOT_PATH="$(cd $(dirname $0); echo $PWD)"
+# this is to support running renode-test from an external directory and via a symlink
+ROOT_PATH="$(cd $(dirname $(readlink -f $0 2>/dev/null || echo $0)); echo $PWD)"
 
 TESTS_FILE="$ROOT_PATH/tests/tests.yaml"
 TESTS_RESULTS="$ROOT_PATH/output/tests"


### PR DESCRIPTION
When building from source, if the resulting binary is symlinked into a users $PATH, eg,
```
$ ls -l ~/.local/bin/renode
lrwxrwxrwx. 1 karlp karlp 33 Jun 20 14:31 /home/karlp/.local/bin/renode -> /home/karlp/src/renode-git/renode
```

Then the shell script will fail to resolve the correct path to ROOT_PATH, and fail to run. Use readlink, which is believed to be cross platform? readlink -f was introduced to macOS 12.3, iiuc.

### Related issue

An issue was not filed, I just directly fixed it.
