### PR TITLE
teensy4.1: add board and test files

### DIFF
--- a/platforms/boards/teensy-41.repl
+++ b/platforms/boards/teensy-41.repl
@@ -1,0 +1,26 @@
+using "platforms/cpus/imxrt1064.repl"
+
+// Teensy 4 uses 100 kHz as SYSTICK
+// see https://github.com/PaulStoffregen/cores/blob/58224e5554d0cda93f92c52078a500a0d898a996/teensy4/startup.c#L223
+nvic:
+    systickFrequency: 100000
+
+// Remapping 0x60000000 to MappedMemory for XIP
+flex_spi: @ sysbus 0x402A8000
+
+flash: SPI.Micron_MT25Q @ flex_spi
+    underlyingMemory: flash_mem
+
+flash_mem: Memory.MappedMemory @ sysbus 0x60000000
+    size: 0x800000
+
+psram: SPI.Micron_MT25Q @ flex_spi2
+    underlyingMemory: psram_mem
+
+psram_mem: Memory.MappedMemory @ sysbus 0x70000000
+    size: 0x800000
+
+gpio7:
+    3 -> led@0
+led: Miscellaneous.LED @ gpio7 3
+

--- a/platforms/cpus/imxrt1064.repl
+++ b/platforms/cpus/imxrt1064.repl
@@ -3,8 +3,12 @@ nvic: IRQControllers.NVIC @ sysbus 0xE000E000
     priorityMask: 0xF0
     IRQ -> cpu@0
 
+dwt: Miscellaneous.DWT @ sysbus 0xE0001000
+    frequency: 72000000
+
 cpu: CPU.CortexM @ sysbus
     cpuType: "cortex-m7"
+    numberOfMPURegions: 16
     nvic: nvic
 
 itcm: Memory.MappedMemory @ sysbus 0x0

--- a/scripts/single-node/teensy-41.resc
+++ b/scripts/single-node/teensy-41.resc
@@ -1,0 +1,25 @@
+
+:name: Teensy 4.1
+:description: This script runs EchoBoth on Teensy 4.1.
+
+using sysbus
+$name?="teensy4.1"
+mach create $name
+machine LoadPlatformDescription @platforms/boards/teensy-41.repl
+
+# make usb PLL happy
+sysbus SetHookAfterPeripheralRead analog01 "if offset == 0x10: value = 0x80003040"
+
+showAnalyzer lpuart6
+
+$bin?=@https://gist.githubusercontent.com/xndcn/b76f45c4ce2e2537975a0e72c1415ceb/raw/b881439670b2955a9935bf08e9a68b20719fd96f/EchoBoth.ino.hex
+macro reset
+"""
+    sysbus LoadHEX $bin
+    # teensy4 hex entry located at 0x60001004
+    $entry=`sysbus ReadDoubleWord 0x60001004`
+
+    cpu PC $entry
+"""
+
+runMacro $reset

--- a/tests/platforms/Teensy-41.robot
+++ b/tests/platforms/Teensy-41.robot
@@ -1,0 +1,21 @@
+
+*** Variables ***
+${UART}                       sysbus.lpuart6
+
+*** Test Cases ***
+Run Example EchoBoth
+    Execute Command           set bin @https://gist.githubusercontent.com/xndcn/b76f45c4ce2e2537975a0e72c1415ceb/raw/b881439670b2955a9935bf08e9a68b20719fd96f/EchoBoth.ino.hex
+    Execute Command           include @scripts/single-node/teensy-41.resc
+
+    Execute Command           showAnalyzer ${UART}
+    Create Terminal Tester    ${UART}
+
+    Start Emulation
+
+    Write To Uart             Hello
+    Wait For Line On Uart     UART received:72
+    Wait For Line On Uart     UART received:101
+    Wait For Line On Uart     UART received:108
+    Wait For Line On Uart     UART received:108
+    Wait For Line On Uart     UART received:111
+


### PR DESCRIPTION
depends on the tlib MPU patch: https://github.com/antmicro/tlib/pull/15
since teensy4.1 protect the whole 4G memory range as NOACCESS:
https://github.com/PaulStoffregen/cores/blob/58224e5554d0cda93f92c52078a500a0d898a996/teensy4/startup.c#L291