### PR TITLE
renode bridge DMI support

### DIFF
--- a/src/Plugins/SystemCPlugin/Peripheral/SystemCPeripheral.cs
+++ b/src/Plugins/SystemCPlugin/Peripheral/SystemCPeripheral.cs
@@ -556,18 +556,18 @@ namespace Antmicro.Renode.Peripherals.SystemC
                         }
                         var readResponseMessage = new RenodeMessage(message.ActionId, message.DataLength,
                             readFromSharedMem ? (byte)1 : (byte)0, message.Address, payload);
-                        
+
                         backwardSocket.Send(readResponseMessage.Serialize(), SocketFlags.None);
                         break;
                     case RenodeAction.DMIReq:
                         bool allowDMI = false;
                         var targetMemory = sysbus.FindMemory(message.Address);
                         if (targetMemory != null) allowDMI = targetMemory.Peripheral.UsingSharedMemory;
-                        long memOffset = (long)message.Address;
-                        ulong segmentStart = (ulong)(memOffset - (memOffset % targetMemory.Peripheral.SegmentSize));
+                        long memBase = (long)(targetMemory.RegistrationPoint.Range.StartAddress + targetMemory.RegistrationPoint.Offset);
+                        long memOffset = (long)message.Address - memBase;
+                        ulong segmentStart = (ulong)memBase + (ulong)(memOffset - (memOffset % targetMemory.Peripheral.SegmentSize));
                         int segmentNo = 0;
                         if (allowDMI) {
-                            memOffset -= (long)(targetMemory.RegistrationPoint.Range.StartAddress + targetMemory.RegistrationPoint.Offset);
                             segmentNo = (int)(memOffset / targetMemory.Peripheral.SegmentSize);
                             allowDMI = segmentNo >= 0 && segmentNo < targetMemory.Peripheral.SegmentCount;
                         }

--- a/src/Plugins/SystemCPlugin/Peripheral/SystemCPeripheral.cs
+++ b/src/Plugins/SystemCPlugin/Peripheral/SystemCPeripheral.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 
 namespace Antmicro.Renode.Peripherals.SystemC
@@ -31,6 +32,7 @@ namespace Antmicro.Renode.Peripherals.SystemC
         Timesync = 3,
         GPIOWrite = 4,
         Reset = 5,
+        DMIReq = 6,
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
@@ -109,6 +111,88 @@ namespace Antmicro.Renode.Peripherals.SystemC
         public readonly byte ConnectionIndex;
         public readonly ulong Address;
         public readonly ulong Payload;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public unsafe struct DMIMessage
+    {
+        public DMIMessage(RenodeAction actionId, byte allowed, ulong startAddress, ulong endAddress, ulong mmfOffset, string mmfPath)
+        {
+            ActionId = actionId;
+            Allowed = allowed;
+            StartAddress = startAddress;
+            EndAddress = endAddress;
+            MMFOffset = mmfOffset;
+            unsafe {
+                byte[] cpySrc = Encoding.ASCII.GetBytes (mmfPath);
+                fixed (byte* cpyDest = MMFPath)
+                {
+                    if (mmfPath.Length < 256)
+                    {
+                        for(int i = 0; i < mmfPath.Length; i++) {
+                            cpyDest[i] = cpySrc[i];
+                        }
+                        cpyDest[mmfPath.Length] = (byte)0;
+                    }
+                    else
+                    {
+                        Logger.Log(LogLevel.Error, "MMF path name is too long");
+                        cpyDest[0] = (byte)0;
+                    }
+                }
+            }
+        }
+
+        public byte[] Serialize()
+        {
+            var size = Marshal.SizeOf(this);
+            var result = new byte[size];
+            var handler = default(GCHandle);
+
+            try
+            {
+                handler = GCHandle.Alloc(result, GCHandleType.Pinned);
+                Marshal.StructureToPtr(this, handler.AddrOfPinnedObject(), false);
+            }
+            finally
+            {
+                if(handler.IsAllocated)
+                {
+                    handler.Free();
+                }
+            }
+
+            return result;
+        }
+
+        public void Deserialize(byte[] message)
+        {
+            var handler = default(GCHandle);
+            try
+            {
+                handler = GCHandle.Alloc(message, GCHandleType.Pinned);
+                this = (DMIMessage)Marshal.PtrToStructure(handler.AddrOfPinnedObject(), typeof(DMIMessage));
+            }
+            finally
+            {
+                if(handler.IsAllocated)
+                {
+                    handler.Free();
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"DMIMessage [{ActionId}@{StartAddress}:{EndAddress}]";
+        }
+
+        public readonly RenodeAction ActionId;
+        public readonly byte Allowed;
+        public readonly ulong StartAddress;
+        public readonly ulong EndAddress;
+        public readonly ulong MMFOffset;
+        public fixed byte MMFPath[256];
     }
 
     public interface IDirectAccessPeripheral : IPeripheral
@@ -400,8 +484,14 @@ namespace Antmicro.Renode.Peripherals.SystemC
                         }
                         break;
                     case RenodeAction.Write:
+                        bool writeToSharedMem = false;
                         if(message.IsSystemBusConnection())
                         {
+                            var targetMem = sysbus.FindMemory(message.Address);
+                            if (targetMem != null)
+                            {
+                                writeToSharedMem = targetMem.Peripheral.UsingSharedMemory;
+                            }
                             sysbus.TryGetCurrentCPU(out var icpu);
                             switch(message.DataLength)
                             {
@@ -427,11 +517,19 @@ namespace Antmicro.Renode.Peripherals.SystemC
                             directAccessPeripherals[message.GetDirectConnectionIndex()].WriteDirect(
                                     message.DataLength, (long)message.Address, message.Payload, message.ConnectionIndex);
                         }
-                        backwardSocket.Send(message.Serialize(), SocketFlags.None);
+                        var writeResponseMessage = new RenodeMessage(message.ActionId, message.DataLength,
+                            writeToSharedMem ? (byte)1 : (byte)0, message.Address, message.Payload);
+                        backwardSocket.Send(writeResponseMessage.Serialize(), SocketFlags.None);
                         break;
                     case RenodeAction.Read:
+                        bool readFromSharedMem = false;
                         if(message.IsSystemBusConnection())
                         {
+                            var targetMem = sysbus.FindMemory(message.Address);
+                            if (targetMem != null)
+                            {
+                                readFromSharedMem = targetMem.Peripheral.UsingSharedMemory;
+                            }
                             sysbus.TryGetCurrentCPU(out var icpu);
                             switch(message.DataLength)
                             {
@@ -456,9 +554,44 @@ namespace Antmicro.Renode.Peripherals.SystemC
                         {
                             payload = directAccessPeripherals[message.GetDirectConnectionIndex()].ReadDirect(message.DataLength, (long)message.Address, message.ConnectionIndex);
                         }
-                        var responseMessage = new RenodeMessage(message.ActionId, message.DataLength,
-                                message.ConnectionIndex, message.Address, payload);
-                        backwardSocket.Send(responseMessage.Serialize(), SocketFlags.None);
+                        var readResponseMessage = new RenodeMessage(message.ActionId, message.DataLength,
+                            readFromSharedMem ? (byte)1 : (byte)0, message.Address, payload);
+                        
+                        backwardSocket.Send(readResponseMessage.Serialize(), SocketFlags.None);
+                        break;
+                    case RenodeAction.DMIReq:
+                        bool allowDMI = false;
+                        var targetMemory = sysbus.FindMemory(message.Address);
+                        if (targetMemory != null) allowDMI = targetMemory.Peripheral.UsingSharedMemory;
+                        long memOffset = (long)message.Address;
+                        ulong segmentStart = (ulong)(memOffset - (memOffset % targetMemory.Peripheral.SegmentSize));
+                        int segmentNo = 0;
+                        if (allowDMI) {
+                            memOffset -= (long)(targetMemory.RegistrationPoint.Range.StartAddress + targetMemory.RegistrationPoint.Offset);
+                            segmentNo = (int)(memOffset / targetMemory.Peripheral.SegmentSize);
+                            allowDMI = segmentNo >= 0 && segmentNo < targetMemory.Peripheral.SegmentCount;
+                        }
+                        if (allowDMI) {
+                            var responseDMIMessage = new DMIMessage (
+                                message.ActionId,
+                                1, // DMI allowed
+                                segmentStart,
+                                segmentStart + (ulong)targetMemory.Peripheral.SegmentSize - 1UL, // segment end
+                                targetMemory.Peripheral.GetSegmentAlignmentOffset(segmentNo), // offset into the MMF corresponding to the segment start address
+                                targetMemory.Peripheral.GetSegmentPath(segmentNo) // MMF path
+                            );
+                            backwardSocket.Send(responseDMIMessage.Serialize(), SocketFlags.None);
+                        } else {
+                            var responseDMIMessage = new DMIMessage (
+                                message.ActionId,
+                                0, // DMI rejected
+                                0UL,
+                                0UL,
+                                0UL,
+                                ""
+                            );
+                            backwardSocket.Send(responseDMIMessage.Serialize(), SocketFlags.None);
+                        }
                         break;
                     default:
                         this.Log(LogLevel.Error, "SystemC integration error - invalid message type {0} sent through backward connection from the SystemC process.", message.ActionId); 

--- a/src/Plugins/SystemCPlugin/SystemCModule/include/renode_bridge.h
+++ b/src/Plugins/SystemCPlugin/SystemCModule/include/renode_bridge.h
@@ -120,6 +120,8 @@ private:
   void service_backward_request(tlm::tlm_generic_payload &payload,
                                 uint8_t connection_idx,
                                 sc_core::sc_time &delay);
+  bool service_backward_request_dmi(tlm::tlm_generic_payload &payload,
+                                    tlm::tlm_dmi &dmi_data);
   int64_t get_systemc_time_us();
 
   // Connection from Renode -> SystemC.

--- a/src/Plugins/SystemCPlugin/SystemCModule/src/renode_bridge.cpp
+++ b/src/Plugins/SystemCPlugin/SystemCModule/src/renode_bridge.cpp
@@ -7,9 +7,17 @@
 #include "renode_bridge.h"
 
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <chrono>
 #include <thread>
+#ifdef __linux__
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
 
 #include "socket-cpp/Socket/TCPClient.h"
 
@@ -44,6 +52,7 @@ enum renode_action : uint8_t {
   // Response:
   //     address: duration of transaction in us
   //     payload: read value
+  //     connection_index: 0=DMI unsupported, 1=DMI supported
   //     Otherwise identical to the request message.
   WRITE = 2,
   // Socket: forward, backward
@@ -54,6 +63,7 @@ enum renode_action : uint8_t {
   //     direct connection payload: value to write
   // Response:
   //     address: duration of transaction in us
+  //     connection_index: 0=DMI unsupported, 1=DMI supported
   //     Otherwise identical to the request message.
   TIMESYNC = 3,
   // Socket: forward only
@@ -82,6 +92,14 @@ enum renode_action : uint8_t {
   //     payload: ignored
   // Response:
   //     Identical to the request message.
+  DMIREQ = 6,
+  // Socket: backward
+  // Request:
+  //     data_length: ignored
+  //     address: address in target's address space
+  //     payload: ignored
+  //     to write connection_index: 0 for SystemBus
+  // Response is a dmi_message.
 };
 
 #pragma pack(push, 1)
@@ -91,6 +109,15 @@ struct renode_message {
   uint8_t connection_index;
   uint64_t address;
   uint64_t payload;
+};
+
+struct dmi_message {
+  renode_action action;
+  uint8_t allowed;
+  uint64_t start_address;
+  uint64_t end_address;
+  uint64_t mmf_offset;
+  char mmf_path[256];
 };
 #pragma pack(pop)
 
@@ -440,6 +467,10 @@ void renode_bridge::service_backward_request(tlm::tlm_generic_payload &payload,
     memcpy(payload.get_data_ptr(), &message.payload, message.data_length);
   }
 
+  if (connection_idx == 0 && message.connection_index == 1) {
+    payload.set_dmi_allowed(true);
+  }
+
   payload.set_response_status(tlm::TLM_OK_RESPONSE);
 }
 
@@ -477,14 +508,69 @@ renode_bridge::target_fw_handler::nb_transport_bw(
 
 void renode_bridge::target_fw_handler::invalidate_direct_mem_ptr(
     sc_dt::uint64, sc_dt::uint64) {
-  fprintf(stderr, "[ERROR] invalidate_direct_mem_ptr not implemented for "
-                  "target_fw_handler.\n");
+    fprintf(stderr, "[ERROR] invalidate_direct_mem_ptr not implemented for "
+                    "target_fw_handler.\n");
 }
 
 bool renode_bridge::target_fw_handler::get_direct_mem_ptr(
     tlm::tlm_generic_payload &trans, tlm::tlm_dmi &dmi_data) {
-  fprintf(stderr, "[ERROR] get_direct_mem_ptr not implemented for "
-                  "target_fw_handler.\n");
+  if (connection_idx != 0) {
+    fprintf(stderr, "[ERROR] get_direct_mem_ptr not implemented for "
+                    "target_fw_handler.\n");
+    return false;
+  } else return bridge->service_backward_request_dmi(trans, dmi_data);
+}
+
+bool renode_bridge::service_backward_request_dmi(tlm::tlm_generic_payload &payload, tlm::tlm_dmi &dmi_data) {
+
+#ifdef __linux__
+  renode_message message = {};
+  message.address = payload.get_address();
+  message.data_length = payload.get_data_length();
+  message.connection_index = 0;
+  message.action = renode_action::DMIREQ;
+
+  dmi_message response;
+
+  backward_connection->Send((char *)&message, sizeof(renode_message));
+
+  backward_connection->Receive((char *)&response, sizeof(dmi_message));
+
+  bool dmi_allowed = response.allowed;
+
+  if (dmi_allowed && response.mmf_offset % sysconf (_SC_PAGESIZE)) {
+      fprintf(stderr, "[ERROR] invalid offset for MMF %s\n", response.mmf_path);
+      dmi_allowed = false;
+  }
+
+  if (dmi_allowed) {
+    dmi_data.allow_read_write();
+    dmi_data.set_start_address (response.start_address);
+    dmi_data.set_end_address (response.end_address);
+    int mmf_fd = open (response.mmf_path, O_RDWR);
+    if (mmf_fd != -1) {
+      unsigned char* mmf_base = static_cast<unsigned char*>(mmap(
+        nullptr,
+        static_cast<size_t>(dmi_data.get_end_address() - dmi_data.get_start_address() + 1),
+        PROT_WRITE|PROT_READ,
+        MAP_SHARED,
+        mmf_fd,
+        response.mmf_offset
+      ));
+      if (mmf_base != MAP_FAILED) {
+        dmi_data.set_dmi_ptr (mmf_base);
+        return true;
+      }
+    }
+  }
+#else
+  // at present DMI support has been implemented for linux only.
+  // print a one-time warning for DMI request on another operating system
+  static bool dmi_disabled_warned = false;
+  if (!dmi_disabled_warned) fprintf(stderr, "[WARNING] DMI support is unimplemented on this operating system\n");
+  dmi_disabled_warned = true;
+#endif
+
   return false;
 }
 

--- a/src/Plugins/SystemCPlugin/SystemCPlugin.csproj
+++ b/src/Plugins/SystemCPlugin/SystemCPlugin.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -31,6 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -50,6 +52,10 @@
     <ProjectReference Include="..\..\Infrastructure\src\Emulator\Peripherals\Peripherals.csproj">
       <Project>{66400796-0C5B-4386-A859-50A2AC3F3DB7}</Project>
       <Name>Peripherals</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\lib\Migrant\Migrant\Migrant.csproj">
+      <Project>{5F87C357-09FB-4F53-BE37-41FE5BD88957}</Project>
+      <Name>Migrant</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Thanks for taking the time to create a Pull Request for Renode!

Please familiarize yourself with our [Contributing guidelines](https://github.com/renode/renode/blob/master/CONTRIBUTING.md) first.

Please note that all contributions to Renode require you to sign a [Contributor License Agreement](https://cla-assistant.io/renode/renode).

Before merging your code to our upstream repositories it will be reviewed by the engineering team working on the project, who will most likely ask you to adapt your code to meet Renode's requirements.

### Related issue

#657 

### Description

Add DMI support for transactions initiated by a SystemC peripheral that target Renode MappedMemory

### Usage example

Enables high performance simulation using a SystemC core model.
Test case submitted at
https://github.com/antmicro/renode-systemc-examples/pull/3

### Additional information

Corresponding renode-infrastructure PR
https://github.com/renode/renode-infrastructure/pull/114
