### PR TITLE
#662 implement transport_dbg, relax timeout check on forwardSocket

### DIFF
--- a/src/Plugins/SystemCPlugin/SystemCModule/include/renode_bridge.h
+++ b/src/Plugins/SystemCPlugin/SystemCModule/include/renode_bridge.h
@@ -33,6 +33,9 @@ public:
                 const char *port);
   ~renode_bridge();
 
+  // Returns true if connection with Renode has been established, false otherwise.
+  bool is_initialized() { return fw_connection_initialized; }
+
 public:
   using renode_bus_target_socket =
       tlm::tlm_target_socket<RENODE_BUSWIDTH, tlm::tlm_base_protocol_types, 1,
@@ -139,6 +142,8 @@ private:
 
   initiator_bw_handler dc_initiators[NUM_DIRECT_CONNECTIONS];
   target_fw_handler dc_targets[NUM_DIRECT_CONNECTIONS];
+
+  bool fw_connection_initialized;
 };
 
 // ================================================================================


### PR DESCRIPTION

### Related issue

#662

### Description

New functionality added:

- Implements the debug transport interface on the SystemC/renode bridge

Existing functionality changed:

- The timeout check is removed on the forwardSocket, so that if the SystemC simulation is stopped by a debugger, Renode will also stop and wait until the SystemC sim resumes


### Usage example

Testcase:
https://github.com/ky-macpherson/renode-issue-reproduction-template/tree/662-add_debugger_support


### Additional information

N/A
