### PR TITLE
Introducing Renode Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ For more information and the underlying Dockerfile, visit the [repository on Git
 
 Documentation is available on [Read the Docs](https://renode.readthedocs.io).
 
+You can also [Ask Renode Guru](https://gurubase.io/g/renode), it is an Renode-focused AI to answer your questions.
+
 ## License & contributions
 
 Renode is released under the permissive MIT license.


### PR DESCRIPTION
Hello Renode team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Renode Guru](https://gurubase.io/g/renode) to Gurubase. Renode Guru uses the data from this repo and data from the [docs](https://renode.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Renode Guru", which highlights that Renode now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Renode Guru in Gurubase, just let me know that's totally fine.