### PR TITLE
Adding optional signals for APB3

### DIFF
--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.cpp
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.cpp
@@ -44,6 +44,7 @@ void APB3::write(int width, uint64_t addr, uint64_t value)
     }
     *psel = 1;
     *pwrite = 1;
+    *pstrb = 1;
     *paddr = addr;
     *pwdata = value;
     tick(true);
@@ -70,6 +71,7 @@ uint64_t APB3::read(int width, uint64_t addr)
     }
     *psel = 1;
     *pwrite = 0;
+    *pstrb = 0;
     *paddr = addr;
     tick(true);
 
@@ -93,8 +95,15 @@ uint64_t APB3::read(int width, uint64_t addr)
 
 void APB3::reset()
 {
+#ifdef RESET_ACTIVE_LOW
+    *prst = 0;
+    tick(true);
+    *prst = 1;
+    tick(true);
+#else
     *prst = 1;
     tick(true);
     *prst = 0;
     tick(true);
+#endif
 }

--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.cpp
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.cpp
@@ -44,7 +44,7 @@ void APB3::write(int width, uint64_t addr, uint64_t value)
     }
     *psel = 1;
     *pwrite = 1;
-    *pstrb = 1;
+    *pstrb = 0xFF;  //As the bus doesn't support the strobe signal - tie all pins high to make all lanes active.
     *paddr = addr;
     *pwdata = value;
     tick(true);

--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.h
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.h
@@ -16,16 +16,16 @@ struct APB3 : public BaseTargetBus
     virtual void reset();
     void timeoutTick(uint8_t* signal, uint8_t expectedValue, int timeout);
 
-    uint8_t  *pclk;
-    uint8_t  *prst;
-    uint8_t *paddr;        // IN
-    uint8_t  *psel;         // IN
-    uint8_t  *penable;      // IN
-    uint8_t  *pwrite;       // IN
+    uint8_t   *pclk;
+    uint8_t   *prst;
+    uint8_t   *paddr;       // IN
+    uint8_t   *psel;        // IN
+    uint8_t   *penable;     // IN
+    uint8_t   *pwrite;      // IN
     uint32_t  *pwdata;      // IN
-    uint8_t  *pready;       // OUT
+    uint8_t   *pready;      // OUT
     uint32_t  *prdata;      // OUT
-    uint8_t  *pslverr;
-    uint8_t  *pstrb;
+    uint8_t   *pslverr;     // IN
+    uint8_t   *pstrb;       // OUT
 };
 #endif

--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.h
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/apb3.h
@@ -26,5 +26,6 @@ struct APB3 : public BaseTargetBus
     uint8_t  *pready;       // OUT
     uint32_t  *prdata;      // OUT
     uint8_t  *pslverr;
+    uint8_t  *pstrb;
 };
 #endif


### PR DESCRIPTION
There are a couple of optional signals in the APB3 interface that our peripherals are using. I've added a minimal change that will satisfy our use cases. However, this is not a comprehensive coverage of all the ways the optional signals could be used.

@PiotrZierhoffer We can have a chat about how this could be incorporated at our regular meeting.
Cheers,
Ed