### PR TITLE
platform: add stm32f439

### DIFF
--- a/platforms/cpus/stm32f439.repl
+++ b/platforms/cpus/stm32f439.repl
@@ -1,0 +1,14 @@
+using "./stm32f4.repl"
+
+sram:
+    size: 0x00030000
+
+ccmDataRam: Memory.MappedMemory @ sysbus 0x10000000
+    size: 0x00010000
+
+ltdc: Video.STM32LTDC @ sysbus 0x40016800
+    -> nvic@88
+
+sysbus:
+    init:
+        ApplySVD @https://raw.githubusercontent.com/modm-io/cmsis-svd-stm32/refs/heads/main/stm32f4/STM32F439.svd


### PR DESCRIPTION
### Related issue

None

### Description

This PR adds support for the STM32f439 series CPUs.

### Usage example

In a repl script simply use

`machine LoadPlatformDescription @platforms/cpus/stm32f439.repl`

### Additional information

The SVD is not being pulled from dl.antmicro since it does not appear to be available there yet.
