### PR TITLE
wishbone: Fix address semantics

### DIFF
--- a/scripts/single-node/litex_vexriscv_verilated_cfu.resc
+++ b/scripts/single-node/litex_vexriscv_verilated_cfu.resc
@@ -8,7 +8,7 @@ mach create $name
 machine LoadPlatformDescription @platforms/cpus/verilated/litex_vexriscv_verilated_cfu.repl
 
 $bin?=@https://dl.antmicro.com/projects/renode/verilated-cfu-test-software.elf-s_10742536-04c41fb55c3011b440a3e6eb955756268f28c151
-$cfuLinux?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-Linux-x86_64-12746432362.so-s_2224440-fb03313c1ba631156fcbbb5593a4f66e4c5fe459
+$cfuLinux?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-Linux-x86_64-13112907851.so-s_2251128-ab2dcb1801188d7f934bdeafa93f9c1edc60ad39
 
 showAnalyzer uart
 

--- a/scripts/single-node/verilated_ibex.resc
+++ b/scripts/single-node/verilated_ibex.resc
@@ -8,9 +8,9 @@ mach create $name
 machine LoadPlatformDescription @platforms/cpus/verilated/verilated_ibex.repl
 
 $bios?=@https://dl.antmicro.com/projects/renode/litex_ibex--bios.bin-s_20712-80d064cf8ab28801b78c0e5a63cac4830016f6c8
-$cpuLinux?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-Linux-x86_64-12746432362.so-s_2224440-fb03313c1ba631156fcbbb5593a4f66e4c5fe459
-$cpuWindows?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-Windows-x86_64-12746432362.dll-s_3401444-3e4e24fdc95d7436b490c95285169b3748ed2b76
-$cpuMacOS?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-macOS-x86_64-12746432362.dylib-s_316064-ca204a33af0e742a326cf3cc407608caed5b225e
+$cpuLinux?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-Linux-x86_64-13112907851.so-s_2251128-ab2dcb1801188d7f934bdeafa93f9c1edc60ad39
+$cpuWindows?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-Windows-x86_64-13112907851.dll-s_3426669-58d11ffc81ea755c1d1151e6b33fc13164bb13d5
+$cpuMacOS?=@https://dl.antmicro.com/projects/renode/libVcpu_ibex-macOS-x86_64-13112907851.dylib-s_336528-7677f09f18bfb2937ad2bffdd63ed7d76bb15d56
 
 showAnalyzer sysbus.uart
 

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/buses/wishbone-initiator.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/buses/wishbone-initiator.h
@@ -131,7 +131,7 @@ public:
             {
                 *wb_stall = low;
                 *wb_ack = low;
-                readWord(*wb_addr, *wb_sel);
+                readWord(*wb_addr * sizeof(data_t), *wb_sel);
                 readState = 1;
             }
             break;
@@ -153,7 +153,7 @@ public:
             {
                 *wb_stall = low;
                 *wb_ack = low;
-                writeWord(*wb_addr, *wb_wr_dat, *wb_sel);
+                writeWord(*wb_addr * sizeof(data_t), *wb_wr_dat, *wb_sel);
                 writeState = 1;
             }
             break;
@@ -184,7 +184,7 @@ public:
         return *wb_cyc && *wb_stb;
     }
     
-    uint64_t getSpecifiedAdress() override { return *wb_addr; }
+    uint64_t getSpecifiedAdress() override { return *wb_addr * sizeof(data_t); }
 
     addr_t *wb_addr;
     data_t *wb_rd_dat;

--- a/tests/platforms/verilated/verilated_ibex_interrupts.robot
+++ b/tests/platforms/verilated/verilated_ibex_interrupts.robot
@@ -1,9 +1,9 @@
 *** Variables ***
 ${URI}                              @https://dl.antmicro.com/projects/renode
 ${UART}                             sysbus.uart
-${CPU_IBEX_NATIVE_LINUX}            ${URI}/libVcpu_ibex-Linux-x86_64-12904733885.so-s_2251128-ee84935737438cde45d07e29650c3770e680c5a3
-${CPU_IBEX_NATIVE_WINDOWS}          ${URI}/libVcpu_ibex-Windows-x86_64-12904733885.dll-s_3426636-7318c5592dcf2a48e7fce8bb13a175ee1cfdd0f4
-${CPU_IBEX_NATIVE_MACOS}            ${URI}/libVcpu_ibex-macOS-x86_64-12904733885.dylib-s_336528-bb23d4db50f720a118047b7c21ded5bf395ae849
+${CPU_IBEX_NATIVE_LINUX}            ${URI}/libVcpu_ibex-Linux-x86_64-13112907851.so-s_2251128-ab2dcb1801188d7f934bdeafa93f9c1edc60ad39
+${CPU_IBEX_NATIVE_WINDOWS}          ${URI}/libVcpu_ibex-Windows-x86_64-13112907851.dll-s_3426669-58d11ffc81ea755c1d1151e6b33fc13164bb13d5
+${CPU_IBEX_NATIVE_MACOS}            ${URI}/libVcpu_ibex-macOS-x86_64-13112907851.dylib-s_336528-7677f09f18bfb2937ad2bffdd63ed7d76bb15d56
 
 *** Keywords ***
 Create Machine

--- a/tests/platforms/verilated/verilated_ibex_litex_bios.robot
+++ b/tests/platforms/verilated/verilated_ibex_litex_bios.robot
@@ -1,9 +1,9 @@
 *** Variables ***
 ${URI}                         @https://dl.antmicro.com/projects/renode
 ${UART}                        sysbus.uart
-${CPU_IBEX_NATIVE_LINUX}       ${URI}/libVcpu_ibex-Linux-x86_64-12904733885.so-s_2251128-ee84935737438cde45d07e29650c3770e680c5a3
-${CPU_IBEX_NATIVE_WINDOWS}     ${URI}/libVcpu_ibex-Windows-x86_64-12904733885.dll-s_3426636-7318c5592dcf2a48e7fce8bb13a175ee1cfdd0f4
-${CPU_IBEX_NATIVE_MACOS}       ${URI}/libVcpu_ibex-macOS-x86_64-12904733885.dylib-s_336528-bb23d4db50f720a118047b7c21ded5bf395ae849
+${CPU_IBEX_NATIVE_LINUX}       ${URI}/libVcpu_ibex-Linux-x86_64-13112907851.so-s_2251128-ab2dcb1801188d7f934bdeafa93f9c1edc60ad39
+${CPU_IBEX_NATIVE_WINDOWS}     ${URI}/libVcpu_ibex-Windows-x86_64-13112907851.dll-s_3426669-58d11ffc81ea755c1d1151e6b33fc13164bb13d5
+${CPU_IBEX_NATIVE_MACOS}       ${URI}/libVcpu_ibex-macOS-x86_64-13112907851.dylib-s_336528-7677f09f18bfb2937ad2bffdd63ed7d76bb15d56
 
 
 *** Test Cases ***

--- a/tests/platforms/verilated/verilated_ibex_pause_resume.robot
+++ b/tests/platforms/verilated/verilated_ibex_pause_resume.robot
@@ -1,9 +1,9 @@
 *** Variables ***
 ${URI}                          @https://dl.antmicro.com/projects/renode
 ${UART}                         sysbus.uart
-${CPU_IBEX_NATIVE_LINUX}        ${URI}/libVcpu_ibex-Linux-x86_64-12904733885.so-s_2251128-ee84935737438cde45d07e29650c3770e680c5a3
-${CPU_IBEX_NATIVE_WINDOWS}      ${URI}/libVcpu_ibex-Windows-x86_64-12904733885.dll-s_3426636-7318c5592dcf2a48e7fce8bb13a175ee1cfdd0f4
-${CPU_IBEX_NATIVE_MACOS}        ${URI}/libVcpu_ibex-macOS-x86_64-12904733885.dylib-s_336528-bb23d4db50f720a118047b7c21ded5bf395ae849
+${CPU_IBEX_NATIVE_LINUX}        ${URI}/libVcpu_ibex-Linux-x86_64-13112907851.so-s_2251128-ab2dcb1801188d7f934bdeafa93f9c1edc60ad39
+${CPU_IBEX_NATIVE_WINDOWS}      ${URI}/libVcpu_ibex-Windows-x86_64-13112907851.dll-s_3426669-58d11ffc81ea755c1d1151e6b33fc13164bb13d5
+${CPU_IBEX_NATIVE_MACOS}        ${URI}/libVcpu_ibex-macOS-x86_64-13112907851.dylib-s_336528-7677f09f18bfb2937ad2bffdd63ed7d76bb15d56
 
 *** Keywords ***
 Create Machine


### PR DESCRIPTION
The [Wishbone spec][1] mandates that ADR_O be addressed in units of data port size, the lower bits being determined by SEL_O.  A similar misrepresentation is present in renode-verilator-integration sample for Ibex, these fixes need to go in tandem.

This change is intended to be used by CoreBlocks Open Source RISC-V CPU for integration with Renode. Currently it would need to be worked around by using extra conversion, like the suggested one in the Ibex PR, but inverted.

Context: https://github.com/kuznia-rdzeni/coreblocks/pull/778

[1]: https://wishbone-interconnect.readthedocs.io/en/latest/02_interface.html#master-signals