### PR TITLE
[#730] Basic Nucleo WB55RG Support

### DIFF
--- a/platforms/boards/nucleo_wb55rg.repl
+++ b/platforms/boards/nucleo_wb55rg.repl
@@ -1,0 +1,6 @@
+using "platforms/cpus/stm32wb55rg.repl"
+
+BlueLED: Miscellaneous.LED @ gpioPortB
+
+gpioPortB:
+    5 -> BlueLED@0

--- a/platforms/cpus/stm32wb55rg.repl
+++ b/platforms/cpus/stm32wb55rg.repl
@@ -1,0 +1,72 @@
+sram1: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x30000
+
+sram2a: Memory.MappedMemory @ sysbus 0x20030000
+    size: 0x8000
+
+sram2b: Memory.MappedMemory @ sysbus 0x20038000
+    size: 0x8000
+
+flash: Memory.MappedMemory @ sysbus 0x08000000
+    size: 0x100000
+
+rcc: Miscellaneous.STM32WBx5_RCC @ sysbus 0x58000000
+    nvic: nvic
+
+pwr: Miscellaneous.STM32WBx5_PWR @ sysbus 0x58000400
+
+hsem: Miscellaneous.STM32WBx5_HardwareSemaphore @ sysbus 0x58001400
+
+gpioPortA: GPIOPort.STM32_GPIOPort @ sysbus <0x48000000, +0x400>
+    modeResetValue: 0xABFFFFFF
+    outputSpeedResetValue: 0x0C000000
+    pullUpPullDownResetValue: 0x64000000
+    numberOfAFs: 16
+
+gpioPortB: GPIOPort.STM32_GPIOPort @ sysbus <0x48000400, +0x400>
+    modeResetValue: 0xFFFFFEBF
+    outputSpeedResetValue: 0x000000C0
+    pullUpPullDownResetValue: 0x00000100
+    numberOfAFs: 16
+
+gpioPortC: GPIOPort.STM32_GPIOPort @ sysbus <0x48000800, +0x400>
+    modeResetValue: 0xFFFFFFFF
+    outputSpeedResetValue: 0x00000000
+    pullUpPullDownResetValue: 0x00000000
+    numberOfAFs: 16
+
+gpioPortD: GPIOPort.STM32_GPIOPort @ sysbus <0x48000C00, +0x400>
+    modeResetValue: 0xFFFFFFFF
+    outputSpeedResetValue: 0x00000000
+    pullUpPullDownResetValue: 0x00000000
+    numberOfAFs: 16
+
+gpioPortE: GPIOPort.STM32_GPIOPort @ sysbus <0x48001000, +0x400>
+    modeResetValue: 0x000003FF
+    outputSpeedResetValue: 0x00000000
+    pullUpPullDownResetValue: 0x00000000
+    numberOfAFs: 16
+
+gpioPortH: GPIOPort.STM32_GPIOPort @ sysbus <0x48001C00, +0x400>
+    modeResetValue: 0x000000CF
+    outputSpeedResetValue: 0x00000000
+    pullUpPullDownResetValue: 0x00000000
+    numberOfAFs: 16
+
+lpuart1: UART.STM32F7_USART @ sysbus 0x40008000
+    frequency: 200000000
+    lowPowerMode: true
+    IRQ -> nvic@48
+
+usart1: UART.STM32F7_USART @ sysbus 0x40013800
+    frequency: 200000000
+    IRQ -> nvic@36
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    priorityMask: 0xF0
+    systickFrequency: 64000000
+    IRQ -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m4"
+    nvic: nvic

--- a/scripts/single-node/nucleo_wb55rg.resc
+++ b/scripts/single-node/nucleo_wb55rg.resc
@@ -1,0 +1,19 @@
+:name: STM32WB55RG Nucleo
+:description: This script runs basic blinky on STM32WB55RG Nucleo.
+
+using sysbus
+$name?="Nucleo WB55RG"
+mach create $name
+
+machine LoadPlatformDescription @platforms/boards/nucleo_wb55rg.repl
+
+showAnalyzer usart1
+
+$bin ?= "/home/nelsmore/projects/personal/sandbox/renode-sandbox/nucleo_fw/build/zephyr/zephyr.elf"
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+
+runMacro $reset

--- a/tests/platforms/nucleo_wb55rg.robot
+++ b/tests/platforms/nucleo_wb55rg.robot
@@ -1,0 +1,41 @@
+*** Variables ***
+${UART}                       sysbus.usart1
+
+*** Test Cases ***
+Run Zephyr Boot
+    Execute Command           include @scripts/single-node/nucleo_wb55rg.resc
+
+    Create Terminal Tester    ${UART}
+
+    Start Emulation
+
+    Wait For Line On Uart     Booting Zephyr OS
+
+Run Blink Uart Status
+    Execute Command           include @scripts/single-node/nucleo_wb55rg.resc
+
+    Create Terminal Tester    ${UART}
+
+    Start Emulation
+
+    Wait For Line On Uart     LED state: OFF
+    ${timeInfo}=              Execute Command   emulation GetTimeSourceInfo
+    Should Contain            ${timeInfo}       Elapsed Virtual Time: 00:00:00
+
+    Wait For Line On Uart     LED state: ON
+    ${timeInfo}=              Execute Command   emulation GetTimeSourceInfo
+    Should Contain            ${timeInfo}       Elapsed Virtual Time: 00:00:01
+
+    Wait For Line On Uart     LED state: OFF
+    ${timeInfo}=              Execute Command   emulation GetTimeSourceInfo
+    Should Contain            ${timeInfo}       Elapsed Virtual Time: 00:00:02
+
+Run Blink Led Status
+    Execute Command           include @scripts/single-node/nucleo_wb55rg.resc
+    Create Terminal Tester    ${UART}
+    Create Led Tester         sysbus.gpioPortB.BlueLED
+
+    Wait For Line On Uart     Booting Zephyr OS
+
+    # durations are in microseconds
+    Assert Led Is Blinking    testDuration=8  onDuration=1  offDuration=1  tolerance=0.001


### PR DESCRIPTION
This adds enough basic support to run the Zephyr basic blinky for the Nucleo WB55RG.  Includes:
- STM32WB55RG repl file with base peripherals
- Nucleo WB55RG repl file
- Nucleo WB55RG resc file
- Nucleo WB55RG robot file