### PR TITLE
[#755] Fix cmake and wix packaging errors under cygwin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -414,7 +414,8 @@ do
     if [[ "$TLIB_EXPORT_COMPILE_COMMANDS" = true ]]; then
         CMAKE_CONF_FLAGS+=" -DCMAKE_EXPORT_COMPILE_COMMANDS=1"
     fi
-    cmake "$CMAKE_GEN" $CMAKE_COMMON $CMAKE_CONF_FLAGS -DHOST_ARCH=$HOST_ARCH $CORES_PATH
+    # cmake doesn't recognize cygwin paths, use relative path
+    cmake "$CMAKE_GEN" $CMAKE_COMMON $CMAKE_CONF_FLAGS -DHOST_ARCH=$HOST_ARCH -S ../../../.. -B .
     cmake --build . -j$(nproc)
     CORE_BIN_DIR=$CORES_BIN_PATH/lib
     mkdir -p $CORE_BIN_DIR

--- a/build.sh
+++ b/build.sh
@@ -359,6 +359,8 @@ CORES_BIN_PATH="$CORES_PATH/bin/$CONFIGURATION"
 if $ON_WINDOWS
 then
     CMAKE_GEN="-GMinGW Makefiles"
+    # Cygwin should create Windows native symlinks so the Wix packaging tool can traverse the path.
+    export CYGWIN="winsymlinks:native"
 else
     CMAKE_GEN="-GUnix Makefiles"
 fi

--- a/tools/packaging/common_copy_files.sh
+++ b/tools/packaging/common_copy_files.sh
@@ -24,12 +24,13 @@ cp -r $BASE/tools/external_control_client $DIR/tools
 cp -r $BASE/src/Plugins/CoSimulationPlugin/IntegrationLibrary $DIR/plugins
 cp -r $BASE/src/Plugins/SystemCPlugin/SystemCModule $DIR/plugins
 # For now, SystemCPlugin uses socket-cpp library from CoSimulationPlugin IntegrationLibrary.
-#
-# The remove call here is to remove a (potential) symlink created by a prior version of this
-# script before doing a directory copy.  Windows builds under cygwin create the symlink but
-# the wix packaging program sees it as an NTFS junction and is unable to process it.
+# ln -f argument is quietly ignored in windows-package environment, so instead of updating remove the link
+# and create it again.
 rm -rf $DIR/plugins/SystemCModule/lib/socket-cpp
-cp -r $DIR/plugins/IntegrationLibrary/libs/socket-cpp $DIR/plugins/SystemCModule/lib
+mkdir -p $DIR/plugins/SystemCModule/lib
+pushd $DIR/plugins/SystemCModule/lib > /dev/null
+ln -s ../../../plugins/IntegrationLibrary/libs/socket-cpp/ ./socket-cpp
+popd  > /dev/null
 
 cp $BASE/tests/requirements.txt $DIR/tests
 cp $BASE/lib/resources/styles/robot.css $DIR/tests

--- a/tools/packaging/common_copy_files.sh
+++ b/tools/packaging/common_copy_files.sh
@@ -24,10 +24,12 @@ cp -r $BASE/tools/external_control_client $DIR/tools
 cp -r $BASE/src/Plugins/CoSimulationPlugin/IntegrationLibrary $DIR/plugins
 cp -r $BASE/src/Plugins/SystemCPlugin/SystemCModule $DIR/plugins
 # For now, SystemCPlugin uses socket-cpp library from CoSimulationPlugin IntegrationLibrary.
-# ln -f argument is quietly ignored in windows-package environment, so instead of updating remove the link
-# and create it again.
+#
+# The remove call here is to remove a (potential) symlink created by a prior version of this
+# script before doing a directory copy.  Windows builds under cygwin create the symlink but
+# the wix packaging program sees it as an NTFS junction and is unable to process it.
 rm -rf $DIR/plugins/SystemCModule/lib/socket-cpp
-ln -s ../../IntegrationLibrary/libs/socket-cpp $DIR/plugins/SystemCModule/lib/socket-cpp
+cp -r $DIR/plugins/IntegrationLibrary/libs/socket-cpp $DIR/plugins/SystemCModule/lib
 
 cp $BASE/tests/requirements.txt $DIR/tests
 cp $BASE/lib/resources/styles/robot.css $DIR/tests


### PR DESCRIPTION
### Related issue

https://github.com/renode/renode/issues/740

### Description

Addresses two issues found when building under Windows (cygwin) per the renode build instructions.

### Usage example

Executing "./build.sh -p" under cygwin results in two issues:

1. cmake error:

CMake Error: The source directory "/cygdrive/c/r/renode/src/Infrastructure/src/Emulator/Cores" does not exist.

2. wix packaging error (once you get past the issue above):

light.exe : error LGHT0001: The file cannot be accessed by the system. [C:\r\renode\tools\packaging\windows\RenodeSetup\SetupProject.wixproj]

### Additional information

NA