### PR TITLE
[#776] SystemC reg write flexible ordering

### DIFF
--- a/src/Plugins/SystemCPlugin/Peripheral/SystemCPeripheral.cs
+++ b/src/Plugins/SystemCPlugin/Peripheral/SystemCPeripheral.cs
@@ -224,6 +224,7 @@ namespace Antmicro.Renode.Peripherals.SystemC
             sysbus = machine.GetSystemBus(this);
 
             directAccessPeripherals = new Dictionary<int, IDirectAccessPeripheral>();
+            IsInitialized = false;
 
             messageLock = new object();
 
@@ -274,6 +275,8 @@ namespace Antmicro.Renode.Peripherals.SystemC
                 }
             }
         }
+
+        public bool IsInitialized { get; private set; }
 
         public ulong ReadQuadWord(long offset)
         {
@@ -362,8 +365,11 @@ namespace Antmicro.Renode.Peripherals.SystemC
                 }
             }
 
-            forwardSocket.Close();
-            backwardSocket.Close();
+            if(forwardSocket != null)
+            {
+                forwardSocket.Close();
+                backwardSocket.Close();
+            }
         }
 
         public IReadOnlyDictionary<int, IGPIO> Connections { get; }
@@ -469,7 +475,7 @@ namespace Antmicro.Renode.Peripherals.SystemC
 
             listenerSocket.Close();
 
-            SendRequest(new RenodeMessage(RenodeAction.Init, 0, 0, 0, (ulong)timeSyncPeriodUS), out var response);
+            IsInitialized = SendRequest(new RenodeMessage(RenodeAction.Init, 0, 0, 0, (ulong)timeSyncPeriodUS), out var response);
 
             backwardThread.Start();
         }


### PR DESCRIPTION


### Related issue

#776

### Description

Fix two issues related to SystemC peripheral monitor command ordering

1. If a write is attempted to a register in the SystemCCPU (e.g. via LoadELF) but the peripheral is not yet initialized (by setting SystemCExecutablePath), the register writes will be queued and then replayed when the peripheral initialization occurs.

2. If the repl contains a SystemC peripheral, and renode is exited before setting the SystemCExecutablePath, renode will exit gracefully instead of core dumping.

### Usage example

Either of these command orderings are now acceptable for a platform that contains a SystemCCPU model

sysbus LoadELF ...
sysbus.cpu SystemCExecutablePath ...

sysbus.cpu SystemCExecutablePath ...
sysbus LoadELF ...



