### PR TITLE
Silicon Labs 25q2 upstream: SixG301 support and other improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/Infrastructure"]
 	path = src/Infrastructure
-	url = https://github.com/renode/renode-infrastructure.git
+	url = https://github.com/SiliconLabsSoftware/renode-infrastructure.git
 [submodule "lib/termsharp"]
 	path = lib/termsharp
 	url = https://github.com/antmicro/termsharp.git

--- a/platforms/boards/silabs/brd1019a.repl
+++ b/platforms/boards/silabs/brd1019a.repl
@@ -1,0 +1,20 @@
+using "platforms/cpus/silabs/sixG30x/sixG301.repl"
+
+led0: Miscellaneous.LED @ gpioPort 66
+
+button0: Miscellaneous.Button @ gpioPort 64
+button1: Miscellaneous.Button @ gpioPort 65
+
+sram:
+    size: 0x80000
+
+flash:
+    size: 0x400000
+
+semailbox:
+    flashSize: 0x400000
+    flashPageSize: 0x1000    
+    flashRegionSize: 0x8000
+    flashCodeRegionStart: 0x30000 // Starts after SE area, which is 192kB for Rainier
+    flashCodeRegionEnd: 0x1E7FFF // Initial code region end address: (flashSize - codeRegionStart)/2
+    flashDataRegionStart: 0x1E8000 // Initial start of data portion

--- a/platforms/boards/silabs/brd4116a.repl
+++ b/platforms/boards/silabs/brd4116a.repl
@@ -1,4 +1,4 @@
-using "platforms/cpus/silabs/efr32s2/efr32mg26.repl"
+using "platforms/cpus/silabs/efr32s2/efr32xG26.repl"
 
 led0: Miscellaneous.LED @ gpioPort 66
 led1: Miscellaneous.LED @ gpioPort 67
@@ -20,7 +20,7 @@ sram:
 flash:
     size: 0x31E000
 
-lockbitsdata: Miscellaneous.SiLabs.EFR32xG2_LockbitsData @ sysbus 0x0831E000
+lockbitsdata: Miscellaneous.SiLabs.SiLabs_LockbitsData @ sysbus 0x0831E000
     size: 0x2000
 
 msc:

--- a/platforms/boards/silabs/brd4117a.repl
+++ b/platforms/boards/silabs/brd4117a.repl
@@ -1,4 +1,4 @@
-using "platforms/cpus/silabs/efr32s2/efr32mg26.repl"
+using "platforms/cpus/silabs/efr32s2/efr32xG26.repl"
 
 led0: Miscellaneous.LED @ gpioPort 66
 led1: Miscellaneous.LED @ gpioPort 67
@@ -20,7 +20,7 @@ sram:
 flash:
     size: 0x31E000
 
-lockbitsdata: Miscellaneous.SiLabs.EFR32xG2_LockbitsData @ sysbus 0x0831E000
+lockbitsdata: Miscellaneous.SiLabs.SiLabs_LockbitsData @ sysbus 0x0831E000
     size: 0x2000
 
 msc:

--- a/platforms/boards/silabs/brd4118a.repl
+++ b/platforms/boards/silabs/brd4118a.repl
@@ -1,4 +1,4 @@
-using "platforms/cpus/silabs/efr32s2/efr32mg26.repl"
+using "platforms/cpus/silabs/efr32s2/efr32xG26.repl"
 
 led0: Miscellaneous.LED @ gpioPort 66
 led1: Miscellaneous.LED @ gpioPort 67
@@ -20,7 +20,7 @@ sram:
 flash:
     size: 0x31E000
 
-lockbitsdata: Miscellaneous.SiLabs.EFR32xG2_LockbitsData @ sysbus 0x0831E000
+lockbitsdata: Miscellaneous.SiLabs.SiLabs_LockbitsData @ sysbus 0x0831E000
     size: 0x2000
 
 msc:

--- a/platforms/boards/silabs/brd4120a.repl
+++ b/platforms/boards/silabs/brd4120a.repl
@@ -1,4 +1,4 @@
-using "platforms/cpus/silabs/efr32s2/efr32mg26.repl"
+using "platforms/cpus/silabs/efr32s2/efr32xG26.repl"
 
 led0: Miscellaneous.LED @ gpioPort 66
 led1: Miscellaneous.LED @ gpioPort 67
@@ -20,7 +20,7 @@ sram:
 flash:
     size: 0x31E000
 
-lockbitsdata: Miscellaneous.SiLabs.EFR32xG2_LockbitsData @ sysbus 0x0831E000
+lockbitsdata: Miscellaneous.SiLabs.SiLabs_LockbitsData @ sysbus 0x0831E000
     size: 0x2000
 
 msc:

--- a/platforms/boards/silabs/brd4121a.repl
+++ b/platforms/boards/silabs/brd4121a.repl
@@ -1,4 +1,4 @@
-using "platforms/cpus/silabs/efr32s2/efr32mg26.repl"
+using "platforms/cpus/silabs/efr32s2/efr32xG26.repl"
 
 led0: Miscellaneous.LED @ gpioPort 66
 led1: Miscellaneous.LED @ gpioPort 67
@@ -20,7 +20,7 @@ sram:
 flash:
     size: 0x31E000
 
-lockbitsdata: Miscellaneous.SiLabs.EFR32xG2_LockbitsData @ sysbus 0x0831E000
+lockbitsdata: Miscellaneous.SiLabs.SiLabs_LockbitsData @ sysbus 0x0831E000
     size: 0x2000
 
 msc:

--- a/platforms/boards/silabs/brd4186c.repl
+++ b/platforms/boards/silabs/brd4186c.repl
@@ -1,4 +1,4 @@
-using "platforms/cpus/silabs/efr32s2/efr32mg24.repl"
+using "platforms/cpus/silabs/efr32s2/efr32xG24.repl"
 
 led0: Miscellaneous.LED @ gpioPort 66
 led1: Miscellaneous.LED @ gpioPort 67
@@ -20,7 +20,7 @@ sram:
 flash:
     size: 0x17E000
 
-lockbitsdata: Miscellaneous.SiLabs.EFR32xG2_LockbitsData @ sysbus 0x0817E000
+lockbitsdata: Miscellaneous.SiLabs.SiLabs_LockbitsData @ sysbus 0x0817E000
     size: 0x2000
 
 msc:

--- a/platforms/boards/silabs/brd4187c.repl
+++ b/platforms/boards/silabs/brd4187c.repl
@@ -1,0 +1,28 @@
+using "platforms/cpus/silabs/efr32s2/efr32xG24.repl"
+
+led0: Miscellaneous.LED @ gpioPort 66
+led1: Miscellaneous.LED @ gpioPort 67
+
+button0: Miscellaneous.Button @ gpioPort 64
+button1: Miscellaneous.Button @ gpioPort 65
+
+deviceInformation:
+    deviceNumber: 1020
+
+radio:
+    pa0DbmSupport: true
+    pa10DbmSupport: true
+    pa20DbmSupport: false
+
+sram:
+    size: 0x40000
+
+flash:
+    size: 0x17E000
+
+lockbitsdata: Miscellaneous.SiLabs.SiLabs_LockbitsData @ sysbus 0x0817E000
+    size: 0x2000
+
+msc:
+    flashSize: 0x180000
+    flashPageSize: 0x2000

--- a/platforms/boards/silabs/brd4402a.repl
+++ b/platforms/boards/silabs/brd4402a.repl
@@ -1,4 +1,4 @@
-using "platforms/cpus/silabs/efr32s2/efr32xg22.repl"
+using "platforms/cpus/silabs/efr32s2/efr32xG22.repl"
 
 sram:
     size: 0x8000

--- a/platforms/boards/silabs/brd4407a.repl
+++ b/platforms/boards/silabs/brd4407a.repl
@@ -1,0 +1,21 @@
+using "platforms/cpus/silabs/sixG30x/sixG301.repl"
+
+led0: Miscellaneous.LED @ gpioPort 66
+led1: Miscellaneous.LED @ gpioPort 67
+
+button0: Miscellaneous.Button @ gpioPort 64
+button1: Miscellaneous.Button @ gpioPort 65
+
+sram:
+    size: 0x80000
+
+flash:
+    size: 0x400000
+
+semailbox:
+    flashSize: 0x400000
+    flashPageSize: 0x1000    
+    flashRegionSize: 0x8000
+    flashCodeRegionStart: 0x30000 // Starts after SE area, which is 192kB for Rainier
+    flashCodeRegionEnd: 0x1E7FFF // Initial code region end address: (flashSize - codeRegionStart)/2
+    flashDataRegionStart: 0x1E8000 // Initial start of data portion

--- a/platforms/cpus/silabs/efr32s2/efr32xG22.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32xG22.repl
@@ -48,7 +48,7 @@ i2c0: I2C.EFR32_I2CController @ {
     }
     -> nvic@27
 
-ldma: DMA.EFR32xG22_LDMA @ {
+ldma: DMA.SiLabs_LDMA_0_1 @ {
         sysbus new Bus.BusMultiRegistration { address: 0x40040000; size: 0x4000; region: "ldma" };     // LDMA_S
         sysbus new Bus.BusMultiRegistration { address: 0x50040000; size: 0x4000; region: "ldma" };     // LDMA_NS
         sysbus new Bus.BusMultiRegistration { address: 0x40044000; size: 0x4000; region: "ldmaxbar" }; // LDMAXBAR_S
@@ -56,7 +56,7 @@ ldma: DMA.EFR32xG22_LDMA @ {
     }
     -> nvic@21
 
-usart0: UART.EFR32xG2_USART_0 @ {
+usart0: UART.SiLabs_USART_0 @ {
         sysbus <0x4005C000, +0x4000>; // USART0_S
         sysbus <0x5005C000, +0x4000>  // USART0_NS
     }
@@ -70,7 +70,7 @@ usart0: UART.EFR32xG2_USART_0 @ {
     TxBufferLowSingleRequest -> ldma@0x1042
     TxEmptyRequest -> ldma@0x0044
 
-usart1: UART.EFR32xG2_USART_0 @ {
+usart1: UART.SiLabs_USART_0 @ {
         sysbus <0x40060000, +0x4000>; // USART1_S
         sysbus <0x50060000, +0x4000>  // USART1_NS
     }
@@ -85,7 +85,7 @@ usart1: UART.EFR32xG2_USART_0 @ {
     TxEmptyRequest -> ldma@0x0054
 
 // TODO: this should be MSC_1
-msc: Miscellaneous.SiLabs.EFR32xG2_MSC_3 @ {
+msc: Miscellaneous.SiLabs.SiLabs_MSC_3 @ {
         sysbus <0x40030000, +0x4000>; // MSC_S
         sysbus <0x50030000, +0x4000>  // MSC_NS
     }
@@ -94,7 +94,7 @@ msc: Miscellaneous.SiLabs.EFR32xG2_MSC_3 @ {
     flashSize: 0x80000
     flashPageSize: 0x2000
 
-gpioPort: GPIOPort.EFR32xG2_GPIO_1 @ {
+gpioPort: GPIOPort.SiLabs_GPIO_1 @ {
         sysbus <0x4003C000, +0x4000>; // GPIO_S
         sysbus <0x5003C000, +0x4000>  // GPIO_NS
     }
@@ -102,7 +102,7 @@ gpioPort: GPIOPort.EFR32xG2_GPIO_1 @ {
     EvenIRQ -> nvic@26
 
 // TODO: this should be TIMER_0
-timer0: Timers.EFR32xG2_TIMER_1 @ {
+timer0: Timers.SiLabs_TIMER_1 @ {
         sysbus <0x40048000, +0x4000>; // TIMER0_S
         sysbus <0x50048000, +0x4000>  // TIMER0_NS
     }
@@ -111,7 +111,7 @@ timer0: Timers.EFR32xG2_TIMER_1 @ {
     -> nvic@7
 
 // TODO: this should be TIMER_0
-timer1: Timers.EFR32xG2_TIMER_1 @ {
+timer1: Timers.SiLabs_TIMER_1 @ {
         sysbus <0x4004C000, +0x4000>; // TIMER1_S
         sysbus <0x5004C000, +0x4000>  // TIMER1_NS
     }
@@ -120,7 +120,7 @@ timer1: Timers.EFR32xG2_TIMER_1 @ {
     -> nvic@8
 
 // TODO: this should be TIMER_0
-timer2: Timers.EFR32xG2_TIMER_1 @ {
+timer2: Timers.SiLabs_TIMER_1 @ {
         sysbus <0x40050000, +0x4000>; // TIMER2_S
         sysbus <0x50050000, +0x4000>  // TIMER2_NS
     }
@@ -129,7 +129,7 @@ timer2: Timers.EFR32xG2_TIMER_1 @ {
     -> nvic@9
 
 // TODO: this should be TIMER_0
-timer3: Timers.EFR32xG2_TIMER_1 @ {
+timer3: Timers.SiLabs_TIMER_1 @ {
         sysbus <0x40054000, +0x4000>; // TIMER3_S
         sysbus <0x50054000, +0x4000>  // TIMER3_NS
     }
@@ -138,7 +138,7 @@ timer3: Timers.EFR32xG2_TIMER_1 @ {
     -> nvic@10
 
 // TODO: this should be TIMER_0
-timer4: Timers.EFR32xG2_TIMER_1 @ {
+timer4: Timers.SiLabs_TIMER_1 @ {
         sysbus <0x40058000, +0x4000>; // TIMER4_S
         sysbus <0x50058000, +0x4000>  // TIMER4_NS
     }
@@ -155,7 +155,7 @@ wtimer0: Timers.EFR32_Timer @ {
     -> nvic@43
 
 // TODO: unclear what version of this block should be used here
-deviceInformation: Miscellaneous.SiLabs.EFR32xG2_DeviceInformation @ sysbus 0x0FE08000
+deviceInformation: Miscellaneous.SiLabs.SiLabs_DeviceInformation @ sysbus 0x0FE08000
     // TODO: change this to BG22 once the DeviceFamily enum is updated
     deviceFamily: DeviceFamily.EFR32MG24
     deviceNumber: 0x1
@@ -168,19 +168,19 @@ DCDC_IF: Python.PythonPeripheral @ sysbus 0x50094024
     script: "request.value = 0xffffffff"
 
 // TODO: this should be CMU_1
-cmu: Miscellaneous.SiLabs.EFR32xG2_CMU_3 @ {
+cmu: Miscellaneous.SiLabs.SiLabs_CMU_3 @ {
         sysbus <0x40008000, +0x4000>; // CMU_S
         sysbus <0x50008000, +0x4000>  // CMU_NS
     }
     hfxo: hfxo
 
 // TODO: this should be HFRCO_1
-hfrco0: Miscellaneous.SiLabs.EFR32xG2_HFRCO_2 @ {
+hfrco0: Miscellaneous.SiLabs.SiLabs_HFRCO_2 @ {
         sysbus <0x40010000, +0x4000>; // HFRCO0_S
         sysbus <0x50010000, +0x4000>  // HFRCO0_NS
     }
 
-hfxo: Miscellaneous.SiLabs.EFR32xG2_HFXO_2 @ {
+hfxo: Miscellaneous.SiLabs.SiLabs_HFXO_2 @ {
         sysbus <0x4000C000, +0x4000>; // HFXO0_S
         sysbus <0x5000C000, +0x4000>  // HFXO0_NS
     }
@@ -188,12 +188,12 @@ hfxo: Miscellaneous.SiLabs.EFR32xG2_HFXO_2 @ {
     IRQ -> nvic@44
 
 // TODO: this should be EMU_1
-emu: Miscellaneous.SiLabs.EFR32xG2_EMU_3 @ {
+emu: Miscellaneous.SiLabs.SiLabs_EMU_3 @ {
         sysbus <0x40004000, +0x4000>; // EMU_S
         sysbus <0x50004000, +0x4000>  // EMU_NS
     }
 
-smu: Miscellaneous.SiLabs.EFR32xG2_SMU_1 @ {
+smu: Miscellaneous.SiLabs.SiLabs_SMU_1 @ {
         sysbus new Bus.BusMultiRegistration { address: 0x44008000; size: 0x4000; region: "smu_s" }; // SMU_S
         sysbus new Bus.BusMultiRegistration { address: 0x54008000; size: 0x4000; region: "smu_ns" } // SMU_NS
     }
@@ -202,18 +202,18 @@ smu: Miscellaneous.SiLabs.EFR32xG2_SMU_1 @ {
     NonSecurePriviledgedIRQ -> nvic@5
 
 // TODO: this should be SYSCFG_1
-syscfg: Miscellaneous.SiLabs.EFR32xG2_SYSCFG_3 @ {
+syscfg: Miscellaneous.SiLabs.SiLabs_SYSCFG_3 @ {
         sysbus <0x4007C000, +0x4000>; // SYSCFG_S
         sysbus <0x5007C000, +0x4000>  // SYSCFG_NS
     }
 
-radioaes: Miscellaneous.SiLabs.EFR32xG2_AES_1 @ {
+radioaes: Miscellaneous.SiLabs.SiLabs_AES_1 @ {
         sysbus <0x44000000, +0x7FF>; // RADIOAES_S
         sysbus <0x54000000, +0x7FF>  // RADIOAES_NS
     }
     IRQ -> nvic@47
 
-cryptoacc_rngctrl: Miscellaneous.SiLabs.EFR32xG2_RNGCTRL @ {
+cryptoacc_rngctrl: Miscellaneous.SiLabs.SiLabs_RNGCTRL @ {
         sysbus new Bus.BusMultiRegistration { address: 0x4C021000; size: 0x7FF; region: "rngctrl_s" };  // CRYPTOACC_RNGCTRL_S
         sysbus new Bus.BusMultiRegistration { address: 0x5C021000; size: 0x7FF; region: "rngctrl_ns" }; // CRYPTOACC_RNGCTRL_NS
         sysbus new Bus.BusMultiRegistration { address: 0x4C024000; size: 0x4000; region: "rngfifo_s" }; // CRYPTOACC_RNGOUT_FIFO_S
@@ -221,7 +221,7 @@ cryptoacc_rngctrl: Miscellaneous.SiLabs.EFR32xG2_RNGCTRL @ {
     }
     IRQ -> nvic@0
 
-itm : Miscellaneous.SiLabs.EFR32xG2_SLAB_ITM @ sysbus 0xE0000000
+itm : Miscellaneous.SiLabs.SiLabs_ITM @ sysbus 0xE0000000
 
 sysbus:
     init add:

--- a/platforms/cpus/silabs/efr32s2/efr32xG24.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32xG24.repl
@@ -2,15 +2,15 @@ i2c0: I2C.EFR32_I2CController @ {
         sysbus <0x4B000000, +0x4000>; // I2C0_S
         sysbus <0x5B000000, +0x4000>  // I2C0_NS
     }
-    -> nvic@41
-
-usart0: UART.EFR32xG2_USART_0 @ {
-        sysbus <0x400A0000, +0x4000>; // USART0_S
-        sysbus <0x500A0000, +0x4000>  // USART0_NS
+    -> nvic@27
+    
+usart0: UART.SiLabs_USART_0 @ {
+        sysbus <0x4005C000, +0x4000>; // USART0_S
+        sysbus <0x5005C000, +0x4000>  // USART0_NS
     }
     clockFrequency: 39000000
-    ReceiveIRQ -> nvic@14
-    TransmitIRQ -> nvic@15
+    ReceiveIRQ -> nvic@9
+    TransmitIRQ -> nvic@10
     RxDataAvailableRequest -> ldma@0x0040
     RxDataAvailableSingleRequest -> ldma@0x1040
     RxDataAvailableGpioSignal -> gpioPort@0x1201
@@ -18,30 +18,31 @@ usart0: UART.EFR32xG2_USART_0 @ {
     TxBufferLowSingleRequest -> ldma@0x1042
     TxEmptyRequest -> ldma@0x0044
 
-eusart0: UART.EFR32xG2_EUSART_2 @ {
+eusart0: UART.SiLabs_EUSART_2 @ {
         sysbus <0x4B010000, +0x4000>; // EUSART0_S
         sysbus <0x5B010000, +0x4000>  // EUSART0_NS
     }
     clockFrequency: 39000000
-    ReceiveIRQ -> nvic@20
-    TransmitIRQ -> nvic@21
+    ReceiveIRQ -> nvic@11
+    TransmitIRQ -> nvic@12
     RxFifoLevel -> ldma@0x00F0
     RxFifoLevelGpioSignal -> gpioPort@0x1202
     TxFifoLevel -> ldma@0x00F1
 
-eusart1: UART.EFR32xG2_EUSART_2 @ {
-        sysbus <0x4008C000, +0x4000>; // EUSART1_S
-        sysbus <0x5008C000, +0x4000>  // EUSART1_NS
+eusart1: UART.SiLabs_EUSART_2 @ {
+        sysbus <0x400A0000, +0x4000>; // EUSART1_S
+        sysbus <0x500A0000, +0x4000>  // EUSART1_NS
     }
     clockFrequency: 39000000
-    ReceiveIRQ -> nvic@22
-    TransmitIRQ -> nvic@23
+    ReceiveIRQ -> nvic@13
+    TransmitIRQ -> nvic@14
     RxFifoLevel -> ldma@0x0100
     RxFifoLevelGpioSignal -> gpioPort@0x1203
     TxFifoLevel -> ldma@0x0101
 
-radio: Wireless.EFR32xG24_Radio @ {
-        sysbus new Bus.BusMultiRegistration { address: 0x4009C000; size: 0x4000; region: "hostmailbox" };
+radio: Wireless.SiLabs_xG24_LPW @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40098000; size: 0x4000; region: "hostmailbox" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50098000; size: 0x4000; region: "hostmailbox_ns" };
         sysbus new Bus.BusMultiRegistration { address: 0xA8004000; size: 0x4000; region: "frc" };
         sysbus new Bus.BusMultiRegistration { address: 0xA800C000; size: 0x4000; region: "agc" };
         sysbus new Bus.BusMultiRegistration { address: 0xA8010000; size: 0x4000; region: "crc" };
@@ -51,7 +52,6 @@ radio: Wireless.EFR32xG24_Radio @ {
         sysbus new Bus.BusMultiRegistration { address: 0xA8020000; size: 0x4000; region: "rac" };
         sysbus new Bus.BusMultiRegistration { address: 0xA802C000; size: 0x4000; region: "rfmailbox" };
         sysbus new Bus.BusMultiRegistration { address: 0xAA000000; size: 0x4000; region: "bufc" };
-        sysbus new Bus.BusMultiRegistration { address: 0x5009C000; size: 0x4000; region: "hostmailbox_ns" };
         sysbus new Bus.BusMultiRegistration { address: 0xB8004000; size: 0x4000; region: "frc_ns" };
         sysbus new Bus.BusMultiRegistration { address: 0xB800C000; size: 0x4000; region: "agc_ns" };
         sysbus new Bus.BusMultiRegistration { address: 0xB8010000; size: 0x4000; region: "crc_ns" };
@@ -64,17 +64,18 @@ radio: Wireless.EFR32xG24_Radio @ {
     }
     ram: sram
     sequencer: seqcpu
+    sysrtc: sysrtc
     // Main CPU interrupts
-    AutomaticGainControlIRQ -> nvic@46
-    BufferControllerIRQ -> nvic@47
-    FrameControllerPrioritizedIRQ -> nvic@48
-    FrameControllerIRQ -> nvic@49
-    ModulatorAndDemodulatorIRQ -> nvic@50
-    ProtocolTimerIRQ -> nvic@51
-    RadioControllerRadioStateMachineIRQ -> nvic@52
-    RadioControllerSequencerIRQ -> nvic@53
-    HostMailboxIRQ -> nvic@54
-    SynthesizerIRQ -> nvic@55
+    AutomaticGainControlIRQ -> nvic@30
+    BufferControllerIRQ -> nvic@31
+    FrameControllerPrioritizedIRQ -> nvic@32
+    FrameControllerIRQ -> nvic@33
+    ModulatorAndDemodulatorIRQ -> nvic@34
+    ProtocolTimerIRQ -> nvic@35
+    RadioControllerRadioStateMachineIRQ -> nvic@36
+    RadioControllerSequencerIRQ -> nvic@37
+    HostMailboxIRQ -> nvic@38
+    SynthesizerIRQ -> nvic@39
     // Sequencer CPU interrupts
     SeqOffIRQ ->seqnvic@0
     SeqRxWarmIRQ ->seqnvic@1
@@ -97,25 +98,24 @@ radio: Wireless.EFR32xG24_Radio @ {
     SeqBufferControllerIRQ ->seqnvic@18
     SeqAutomaticGainControlIRQ ->seqnvic@19
     SeqProtocolTimerIRQ -> seqnvic@20
-    //SeqRtcIRQ -> seqnvic@21
     SeqSynthesizerIRQ -> seqnvic@22
     SeqRfMailboxIRQ -> seqnvic@23
 
-msc: Miscellaneous.SiLabs.EFR32xG2_MSC_3 @ {
+msc: Miscellaneous.SiLabs.SiLabs_MSC_3 @ {
         sysbus <0x40030000, +0x4000>; // MSC_S
         sysbus <0x50030000, +0x4000>  // MSC_NS
     }
     cpu: cpu
-    IRQ -> nvic@66
-    flashSize: 0x320000
+    IRQ -> nvic@50
+    flashSize: 0x180000
     flashPageSize: 0x2000
 
-gpioPort: GPIOPort.EFR32xG2_GPIO_3 @ {
+gpioPort: GPIOPort.SiLabs_GPIO_3 @ {
         sysbus <0x4003C000, +0x4000>; // GPIO_S
         sysbus <0x5003C000, +0x4000>  // GPIO_NS
     }
-    EvenIRQ -> nvic@40
-    OddIRQ -> nvic@39
+    EvenIRQ -> nvic@26
+    OddIRQ -> nvic@25
 
 bitclear: Miscellaneous.BitAccess
     address: 0x2000
@@ -126,7 +126,7 @@ bitset: Miscellaneous.BitAccess
     mode: BitAccessMode.Set
 
 sram: Memory.MappedMemory @ sysbus 0x20000000
-    size: 0x80000
+    size: 0x40000
 
 seqram: Memory.MappedMemory @ {
         sysbus 0xA0000000;
@@ -155,6 +155,7 @@ nvic: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
         cpu: cpu
     }
     -> cpu@0
+    systickFrequency: 39000000
 
 seqnvic: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
         address: 0xE000E000;
@@ -173,12 +174,12 @@ seqcpu: CPU.CortexM @ sysbus
     cpuId: 1
     IsHalted: true
 
-timer0: Timers.EFR32_Timer @ {
+timer0: Timers.SiLabs_TIMER_1 @ {
         sysbus <0x40048000, +0x4000>; // TIMER0_S
         sysbus <0x50048000, +0x4000>  // TIMER0_NS
     }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
+    frequency: 20000000 //expected frequency for power manager HW tests
+    width: 16
     -> nvic@4
 
 timer1: Timers.EFR32_Timer @ {
@@ -189,78 +190,13 @@ timer1: Timers.EFR32_Timer @ {
     width: TimerWidth.Bit16
     -> nvic@5
 
-timer2: Timers.EFR32_Timer @ {
-        sysbus <0x40050000, +0x4000>; // TIMER2_S
-        sysbus <0x50050000, +0x4000>  // TIMER2_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@6
-
-timer3: Timers.EFR32_Timer @ {
-        sysbus <0x40054000, +0x4000>; // TIMER3_S
-        sysbus <0x50054000, +0x4000>  // TIMER3_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@7
-
-timer4: Timers.EFR32_Timer @ {
-        sysbus <0x40058000, +0x4000>; // TIMER4_S
-        sysbus <0x50058000, +0x4000>  // TIMER4_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@8
-
-timer5: Timers.EFR32_Timer @ {
-        sysbus <0x4005C000, +0x4000>; // TIMER5_S
-        sysbus <0x5005C000, +0x4000>  // TIMER5_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@9
-
-timer6: Timers.EFR32_Timer @ {
-        sysbus <0x40060000, +0x4000>; // TIMER6_S
-        sysbus <0x50060000, +0x4000>  // TIMER6_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@10
-
-timer7: Timers.EFR32_Timer @ {
-        sysbus <0x40064000, +0x4000>; // TIMER7_S
-        sysbus <0x50064000, +0x4000>  // TIMER7_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@11
-
-
-timer8: Timers.EFR32_Timer @ {
-        sysbus <0x40068000, +0x4000>; // TIMER8_S
-        sysbus <0x50068000, +0x4000>  // TIMER8_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@12
-
-timer9: Timers.EFR32_Timer @ {
-        sysbus <0x4006C000, +0x4000>; // TIMER9_S
-        sysbus <0x5006C000, +0x4000>  // TIMER9_NS
-    }
-    frequency: 0x1000000 //bogus
-    width: TimerWidth.Bit16
-    -> nvic@13
-
-ldma: DMA.EFR32MG24_LDMA @ {
+ldma: DMA.SiLabs_LDMA_0_3 @ {
         sysbus new Bus.BusMultiRegistration { address: 0x40040000; size: 0x4000; region: "ldma" };     // LDMA_S
         sysbus new Bus.BusMultiRegistration { address: 0x50040000; size: 0x4000; region: "ldma" };     // LDMA_NS
         sysbus new Bus.BusMultiRegistration { address: 0x40044000; size: 0x4000; region: "ldmaxbar" }; // LDMAXBAR_S
         sysbus new Bus.BusMultiRegistration { address: 0x50044000; size: 0x4000; region: "ldmaxbar" }  // LDMAXBAR_NS
     }
-    -> nvic@35
+    -> nvic@21
 
 wtimer0: Timers.EFR32_Timer @ {
         sysbus <0x4B004000, +0x4000>; // WDOG0_S
@@ -268,7 +204,7 @@ wtimer0: Timers.EFR32_Timer @ {
     }
     frequency: 0x1000000 //bogus
     width: TimerWidth.Bit32
-    -> nvic@58
+    -> nvic@42
 
 wtimer1: Timers.EFR32_Timer @ {
         sysbus <0x4B008000, +0x4000>; // WDOG1_S
@@ -276,104 +212,115 @@ wtimer1: Timers.EFR32_Timer @ {
     }
     frequency: 0x1000000 //bogus
     width: TimerWidth.Bit32
-    -> nvic@59
+    -> nvic@43
 
-deviceInformation: Miscellaneous.SiLabs.EFR32xG2_DeviceInformation @ sysbus 0x0FE08000
-    deviceFamily: DeviceFamily.EFR32MG26
+deviceInformation: Miscellaneous.SiLabs.SiLabs_DeviceInformation @ sysbus 0x0FE08000
+    deviceFamily: DeviceFamily.EFR32MG24
     deviceNumber: 0x1
     flashDevice: flash
     sramDevice: sram
 
-DCDC_IF: Python.PythonPeripheral @ sysbus 0x50098028
+DCDC_IF: Python.PythonPeripheral @ sysbus 0x50094028
     size: 0x4
     initable: true
     script: "request.value = 0xffffffff"
 
 flash: Memory.MappedMemory @ sysbus 0x08000000
-    size: 0x31E000
+    size: 0x17E000
 
-cmu: Miscellaneous.SiLabs.EFR32xG2_CMU_3 @ {
+cmu: Miscellaneous.SiLabs.SiLabs_CMU_3 @ {
         sysbus <0x40008000, +0x4000>; // CMU_S
         sysbus <0x50008000, +0x4000>  // CMU_NS
     }
     hfxo: hfxo
     dpll: dpll
 
-lfxo: Miscellaneous.SiLabs.EFR32xG2_LFXO_1 @ {
+lfxo: Miscellaneous.SiLabs.SiLabs_LFXO_1 @ {
         sysbus <0x40020000, +0x4000>; // LFXO_S
         sysbus <0x50020000, +0x4000>  // LFXO_NS
     }
 
-hfrco0: Miscellaneous.SiLabs.EFR32xG2_HFRCO_2 @ {
+hfrco0: Miscellaneous.SiLabs.SiLabs_HFRCO_2 @ {
         sysbus <0x40010000, +0x4000>; // HFRCO_S
         sysbus <0x50010000, +0x4000>  // HFRCO_NS
     }
 
-dpll: Miscellaneous.SiLabs.EFR32xG2_DPLL_1 @ {
+dpll: Miscellaneous.SiLabs.SiLabs_DPLL_1 @ {
         sysbus <0x4001C000, +0x4000>; // DPLL0_S
         sysbus <0x5001C000, +0x4000>  // DPLL0_NS
     }
 
-lfrco: Miscellaneous.SiLabs.EFR32xG2_LFRCO_2 @ {
+lfrco: Miscellaneous.SiLabs.SiLabs_LFRCO_2 @ {
         sysbus <0x40024000, +0x4000>; // LFRCO_S
         sysbus <0x50024000, +0x4000>  // LFRCO_NS
     }
 
-hfxo: Miscellaneous.SiLabs.EFR32xG2_HFXO_3 @ {
+hfxo: Miscellaneous.SiLabs.SiLabs_HFXO_3 @ {
         sysbus <0x4A004000, +0x4000>; // HFXO0_S
         sysbus <0x5A004000, +0x4000>  // HFXO0_NS
     }
+    startupDelayTicks: 3   //should remain <= 20 to pass early wakeup conditions
+    IRQ -> nvic@44
 
-hfrcoem23: Miscellaneous.SiLabs.EFR32xG2_HFRCO_2 @ {
+hfrco1: Miscellaneous.SiLabs.SiLabs_HFRCO_2 @ {
         sysbus <0x4A000000, +0x4000>; // HFRCOEM23_S
         sysbus <0x5A000000, +0x4000>  // HFRCOEM23_NS
     }
 
-emu: Miscellaneous.SiLabs.EFR32xG2_EMU_3 @ {
+emu: Miscellaneous.SiLabs.SiLabs_EMU_3 @ {
         sysbus <0x40004000, +0x4000>; // EMU_S
         sysbus <0x50004000, +0x4000>  // EMU_NS
     }
 
-syscfg: Miscellaneous.SiLabs.EFR32xG2_SYSCFG_3 @ {
+syscfg: Miscellaneous.SiLabs.SiLabs_SYSCFG_3 @ {
         sysbus <0x4007C000, +0x4000>; // SYSCFG_S
         sysbus <0x5007C000, +0x4000>  // SYSCFG_NS
     }
 
-sysrtc: Miscellaneous.SiLabs.EFR32xG2_SYSRTC_1 @ {
-        sysbus <0x400AC000, +0x4000>; // SYSRTC0_S
-        sysbus <0x500AC000, +0x4000>  // SYSRTC0_NS
+sysrtc: Timers.SiLabs_SYSRTC_1 @ {
+        sysbus <0x400A8000, +0x4000>; // SYSRTC0_S
+        sysbus <0x500A8000, +0x4000>  // SYSRTC0_NS
     }   
     frequency: 32768
-    IRQ -> nvic@83
+    IRQ -> nvic@67
+    AlternateIRQ -> seqnvic@21
 
-semailbox: Miscellaneous.SiLabs.EFR32xG2_SEMAILBOX_1 @ {
+semailbox: Miscellaneous.SiLabs.SiLabs_SEMAILBOX_1 @ {
         sysbus <0x4C000000, +0x4000>; // SEMAILBOX_S
         sysbus <0x5C000000, +0x4000>  // SEMAILBOX_NS
     }
-    RxIRQ -> nvic@81
-    TxIRQ -> nvic@82
+    RxIRQ -> nvic@65
+    TxIRQ -> nvic@66
 
-radioaes: Miscellaneous.SiLabs.EFR32xG2_AES_1 @ {
+prs: Miscellaneous.SiLabs.SiLabs_PRS_3 @ {
+        sysbus <0x40038000, +0x4000>; // PRS_S
+        sysbus <0x50038000, +0x4000>  // PRS_NS
+    }
+    hfxo: hfxo
+    sysrtc: sysrtc
+    lpw: radio
+
+radioaes: Miscellaneous.SiLabs.SiLabs_AES_1 @ {
         sysbus <0x44000000, +0x4000>; // RADIOAES_S
         sysbus <0x54000000, +0x4000>  // RADIOAES_NS
     }
-    IRQ -> nvic@64
+    IRQ -> nvic@48
 
-flashuserdata: Miscellaneous.SiLabs.EFR32xG24_FlashUserData @ sysbus <0x0FE00000, +0x7F>
+flashuserdata: Miscellaneous.SiLabs.SiLabs_FlashUserData @ sysbus <0x0FE00000, +0x7F>
+
+itm : Miscellaneous.SiLabs.SiLabs_ITM @ sysbus 0xE0000000
 
 sysbus:
     init add:
         Tag <0x40000000, 0x40003FFF> "SCRATCHPAD_S"
         Tag <0x40004000, 0x40007FFF> "EMU_S"
         Tag <0x40008000, 0x4000BFFF> "CMU_S"
-        Tag <0x4000C000, 0x4000FFFF> "BURTC_S"
         Tag <0x40010000, 0x40013FFF> "HFRCO0_S"
         Tag <0x40018000, 0x4001BFFF> "FSRCO_S"
         Tag <0x4001C000, 0x4001FFFF> "DPLL0_S"
         Tag <0x40020000, 0x40023FFF> "LFXO_S"
         Tag <0x40024000, 0x40027FFF> "LFRCO_S"
         Tag <0x40028000, 0x4002BFFF> "ULFRCO_S"
-        Tag <0x4002C000, 0x4002FFFF> "KEYSCAN_S"
         Tag <0x40030000, 0x40033FFF> "MSC_S"
         Tag <0x40034000, 0x40037FFF> "ICACHE0_S"
         Tag <0x40038000, 0x4003BFFF> "PRS_S"
@@ -385,40 +332,26 @@ sysbus:
         Tag <0x40050000, 0x40053FFF> "TIMER2_S"
         Tag <0x40054000, 0x40057FFF> "TIMER3_S"
         Tag <0x40058000, 0x4005BFFF> "TIMER4_S"
-        Tag <0x4005C000, 0x4005FFFF> "TIMER5_S"
-        Tag <0x40060000, 0x40063FFF> "TIMER6_S"
-        Tag <0x40064000, 0x40067FFF> "TIMER7_S"
-        Tag <0x40068000, 0x4006BFFF> "TIMER8_S"
-        Tag <0x4006C000, 0x4006FFFF> "TIMER9_S"
-        Tag <0x40070000, 0x40073FFF> "CHIPTESTCTRL_S"
-        Tag <0x40074000, 0x40077FFF> "DMEM0_S"
-        Tag <0x40078000, 0x4007BFFF> "DMEM1_S"
-        Tag <0x4007C000, 0x4007FFFF> "SYSCFG_S_CFGNS"
-        Tag <0x40080000, 0x40083FFF> "SYSCFG_S"
-        Tag <0x40084000, 0x40087FFF> "BURAM_S"
+        Tag <0x4005C000, 0x4005FFFF> "USART0_S"
+        Tag <0x40064000, 0x40067FFF> "BURTC_S"
+        Tag <0x40068000, 0x4006BFFF> "I2C1_S"
+        Tag <0x40078000, 0x4007BFFF> "SYSCFG_S_CFGNS"
+        Tag <0x4007C000, 0x4007FFFF> "SYSCFG_S"
+        Tag <0x40080000, 0x40083FFF> "BURAM_S"
         Tag <0x40088000, 0x4008BFFF> "GPCRC_S"
-        Tag <0x4008C000, 0x4008FFFF> "EUSART1_S"
-        Tag <0x40090000, 0x40093FFF> "EUSART2_S"
-        Tag <0x40094000, 0x40097FFF> "EUSART3_S"
-        Tag <0x40098000, 0x4009BFFF> "DCDC_S"
-        Tag <0x4009C000, 0x4009FFFF> "HOSTMAILBOX_S"
-        Tag <0x400A0000, 0x400A3FFF> "USART0_S"
-        Tag <0x400A4000, 0x400A7FFF> "USART1_S"
-        Tag <0x400A8000, 0x400ABFFF> "USART2_S"
-        Tag <0x400AC000, 0x400AFFFF> "SYSRTC0_S"
-        Tag <0x400B0000, 0x400B3FFF> "I2C1_S"
-        Tag <0x400B4000, 0x400B7FFF> "I2C2_S"
-        Tag <0x400B8000, 0x400BBFFF> "I2C3_S"
-        Tag <0x400BC000, 0x400BFFFF> "LCD_S"
-        Tag <0x400C0000, 0x400C3FFF> "LCDRF_S"
-        Tag <0x44000000, 0x440007FF> "RADIOAES_S"
+        Tag <0x40094000, 0x40097FFF> "DCDC_S"
+        Tag <0x40098000, 0x4009BFFF> "HOSTMAILBOX_S"
+        Tag <0x400A0000, 0x400A3FFF> "EUSART1_S"
+        Tag <0x400A8000, 0x400ABFFF> "SYSRTC0_S"
+        Tag <0x400B0000, 0x400B3FFF> "KEYSCAN_S"
+        Tag <0x400B4000, 0x400B7FFF> "DMEM_S"
+        Tag <0x44000000, 0x44003FFF> "RADIOAES_S"
         Tag <0x44008000, 0x4400BFFF> "SMU_S"
         Tag <0x4400C000, 0x4400FFFF> "SMU_S_CFGNS"
         Tag <0x49000000, 0x49003FFF> "LETIMER0_S"
         Tag <0x49004000, 0x49007FFF> "IADC0_S"
         Tag <0x49008000, 0x4900BFFF> "ACMP0_S"
         Tag <0x4900C000, 0x4900FFFF> "ACMP1_S"
-        Tag <0x49020000, 0x49023FFF> "AMUXCP0_S"
         Tag <0x49024000, 0x49027FFF> "VDAC0_S"
         Tag <0x49028000, 0x4902BFFF> "VDAC1_S"
         Tag <0x49030000, 0x49033FFF> "PCNT0_S"
@@ -428,27 +361,13 @@ sysbus:
         Tag <0x4B004000, 0x4B007FFF> "WDOG0_S"
         Tag <0x4B008000, 0x4B00BFFF> "WDOG1_S"
         Tag <0x4B010000, 0x4B013FFF> "EUSART0_S"
-        Tag <0x4C000000, 0x4C00007F> "SEMAILBOX_S"
+        Tag <0x4C000000, 0x4C003FFF> "SEMAILBOX_S"
         Tag <0x4D000000, 0x4D003FFF> "MVP_S"
-        Tag <0xA8004000, 0xA8007FFF> "FRC_S"
-        Tag <0xA800C000, 0xA800FFFF> "AGC_S"
-        Tag <0xA8010000, 0xA8013FFF> "RFCRC_S"
-        Tag <0xA8014000, 0xA8017FFF> "MODEM_S"
-        Tag <0xA8018000, 0xA801BFFF> "SYNTH_S"
-        Tag <0xA801C000, 0xA801FFFF> "PROTIMER_S"
-        Tag <0xA8020000, 0xA8023FFF> "RAC_S"
-        Tag <0xA8024000, 0xA8027FFF> "RFSCRATCHPAD_S"
-        Tag <0xA802C000, 0xA802FFFF> "RFMAILBOX_S"
-        Tag <0xA8030000, 0xA8033FFF> "RFECA0_S"
-        Tag <0xA8034000, 0xA8037FFF> "RFECA1_S"
-        Tag <0xA8038000, 0xA803BFFF> "ECAIFADC_S"
-        Tag <0xAA000000, 0xAA003FFF> "BUFC_S"
         Tag <0x50000000, 0x50003FFF> "SCRATCHPAD_NS"
         Tag <0x50004000, 0x50007FFF> "EMU_NS"
         Tag <0x50008000, 0x5000BFFF> "CMU_NS"
-        Tag <0x5000C000, 0x5000FFFF> "BURTC_NS"
         Tag <0x50010000, 0x50013FFF> "HFRCO0_NS"
-        Tag <0x50018000, 0x5001BFFF> "FSRCO0_NS"
+        Tag <0x50018000, 0x5001BFFF> "FSRCO_NS"
         Tag <0x5001C000, 0x5001FFFF> "DPLL0_NS"
         Tag <0x50020000, 0x50023FFF> "LFXO_NS"
         Tag <0x50024000, 0x50027FFF> "LFRCO_NS"
@@ -464,40 +383,26 @@ sysbus:
         Tag <0x50050000, 0x50053FFF> "TIMER2_NS"
         Tag <0x50054000, 0x50057FFF> "TIMER3_NS"
         Tag <0x50058000, 0x5005BFFF> "TIMER4_NS"
-        Tag <0x5005C000, 0x5005FFFF> "TIMER5_NS"
-        Tag <0x50060000, 0x50063FFF> "TIMER6_NS"
-        Tag <0x50064000, 0x50067FFF> "TIMER7_NS"
-        Tag <0x50068000, 0x5006BFFF> "TIMER8_NS"
-        Tag <0x5006C000, 0x5006FFFF> "TIMER9_NS"
-        Tag <0x50070000, 0x50073FFF> "CHIPTESTCTRL_NS"
-        Tag <0x50074000, 0x50077FFF> "DMEM0_NS"
-        Tag <0x50078000, 0x5007BFFF> "DMEM1_NS"
-        Tag <0x5007C000, 0x5007FFFF> "SYSCFG_NS_CFGNS"
-        Tag <0x50080000, 0x50083FFF> "SYSCFG_NS"
-        Tag <0x50084000, 0x50087FFF> "BURAM_NS"
+        Tag <0x5005C000, 0x5005FFFF> "USART0_NS"
+        Tag <0x50064000, 0x50067FFF> "BURTC_NS"
+        Tag <0x50068000, 0x5006BFFF> "I2C1_NS"
+        Tag <0x50078000, 0x5007BFFF> "SYSCFG_NS_CFGNS"
+        Tag <0x5007C000, 0x5007FFFF> "SYSCFG_NS"
+        Tag <0x50080000, 0x50083FFF> "BURAM_NS"
         Tag <0x50088000, 0x5008BFFF> "GPCRC_NS"
-        Tag <0x5008C000, 0x5008FFFF> "EUSART1_NS"
-        Tag <0x50090000, 0x50093FFF> "EUSART2_NS"
-        Tag <0x50094000, 0x50097FFF> "EUSART3_NS"
-        Tag <0x50098000, 0x5009BFFF> "DCDC_NS"
-        Tag <0x5009C000, 0x5009FFFF> "HOSTMAILBOX_NS"
-        Tag <0x500A0000, 0x500A3FFF> "USART0_NS"
-        Tag <0x500A4000, 0x500A7FFF> "USART1_NS"
-        Tag <0x500A8000, 0x500ABFFF> "USART2_NS"
-        Tag <0x500AC000, 0x500AFFFF> "SYSRTC0_NS"
-        Tag <0x500B0000, 0x500B3FFF> "I2C1_NS"
-        Tag <0x500B4000, 0x500B7FFF> "I2C2_NS"
-        Tag <0x500A8000, 0x500ABFFF> "I2C3_NS"
-        Tag <0x500BC000, 0x500BFFFF> "LCD_NS"
-        Tag <0x500C0000, 0x500C3FFF> "LCDRF_NS"
-        Tag <0x54000000, 0x540007FF> "RADIOAES_NS"
+        Tag <0x50094000, 0x50097FFF> "DCDC_NS"
+        Tag <0x50098000, 0x5009BFFF> "HOSTMAILBOX_NS"
+        Tag <0x500A0000, 0x500A3FFF> "EUSART1_NS"
+        Tag <0x500A8000, 0x500ABFFF> "SYSRTC0_NS"
+        Tag <0x500B0000, 0x500B3FFF> "KEYSCAN_NS"
+        Tag <0x500B4000, 0x500B7FFF> "DMEM_NS"
+        Tag <0x54000000, 0x54003FFF> "RADIOAES_NS"
         Tag <0x54008000, 0x5400BFFF> "SMU_NS"
         Tag <0x5400C000, 0x5400FFFF> "SMU_NS_CFGNS"
-        Tag <0x59000000, 0x59003FFF> "LETIMER_NS"
+        Tag <0x59000000, 0x59003FFF> "LETIMER0_NS"
         Tag <0x59004000, 0x59007FFF> "IADC0_NS"
         Tag <0x59008000, 0x5900BFFF> "ACMP0_NS"
         Tag <0x5900C000, 0x5900FFFF> "ACMP1_NS"
-        Tag <0x59020000, 0x59023FFF> "AMUXCP0_NS"
         Tag <0x59024000, 0x59027FFF> "VDAC0_NS"
         Tag <0x59028000, 0x5902BFFF> "VDAC1_NS"
         Tag <0x59030000, 0x59033FFF> "PCNT0_NS"
@@ -507,20 +412,26 @@ sysbus:
         Tag <0x5B004000, 0x5B007FFF> "WDOG0_NS"
         Tag <0x5B008000, 0x5B00BFFF> "WDOG1_NS"
         Tag <0x5B010000, 0x5B013FFF> "EUSART0_NS"
-        Tag <0x5C000000, 0x5C00007F> "SEMAILBOX_NS"
         Tag <0x5D000000, 0x5D003FFF> "MVP_NS"
+        Tag <0x54000000, 0x540007FF> "RADIOAES_NS"
+        Tag <0x5C000000, 0x5C00007F> "SEMAILBOX_NS"
+        Tag <0xA8004000, 0xA8007FFF> "FRC"
+        Tag <0xA800C000, 0xA800FFFF> "AGC"
+        Tag <0xA8010000, 0xA8013FFF> "CRC"
+        Tag <0xA8014000, 0xA8017FFF> "MODEM"
+        Tag <0xA8018000, 0xA801BFFF> "SYNTH"
+        Tag <0xA801C000, 0xA801FFFF> "PROTIMER"
+        Tag <0xA8020000, 0xA8023FFF> "RAC"
+        Tag <0xA802C000, 0xA802FFFF> "RFMAILBOX"
+        Tag <0xAA000000, 0xAA003FFF> "BUFC"
         Tag <0xB8004000, 0xB8007FFF> "FRC_NS"
         Tag <0xB800C000, 0xB800FFFF> "AGC_NS"
-        Tag <0xB8010000, 0xB8013FFF> "RFCRC_NS"
+        Tag <0xB8010000, 0xB8013FFF> "CRC_NS"
         Tag <0xB8014000, 0xB8017FFF> "MODEM_NS"
         Tag <0xB8018000, 0xB801BFFF> "SYNTH_NS"
         Tag <0xB801C000, 0xB801FFFF> "PROTIMER_NS"
         Tag <0xB8020000, 0xB8023FFF> "RAC_NS"
-        Tag <0xB8024000, 0xB8027FFF> "RFSCRATCHPAD_NS"
         Tag <0xB802C000, 0xB802FFFF> "RFMAILBOX_NS"
-        Tag <0xB8030000, 0xB8033FFF> "RFECA0_NS"
-        Tag <0xB8034000, 0xB8037FFF> "RFECA1_NS"
-        Tag <0xB8038000, 0xB803BFFF> "ECAIFADC_NS"
         Tag <0xBA000000, 0xBA003FFF> "BUFC_NS"
         Tag <0xE0000000, 0xE0000FFF> "ITM"
         Tag <0x0FE00000, 0x0FE00009> "FLASH_USER_DATA"

--- a/platforms/cpus/silabs/efr32s2/efr32xG26.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32xG26.repl
@@ -2,15 +2,15 @@ i2c0: I2C.EFR32_I2CController @ {
         sysbus <0x4B000000, +0x4000>; // I2C0_S
         sysbus <0x5B000000, +0x4000>  // I2C0_NS
     }
-    -> nvic@27
-    
-usart0: UART.EFR32xG2_USART_0 @ {
-        sysbus <0x4005C000, +0x4000>; // USART0_S
-        sysbus <0x5005C000, +0x4000>  // USART0_NS
+    -> nvic@41
+
+usart0: UART.SiLabs_USART_0 @ {
+        sysbus <0x400A0000, +0x4000>; // USART0_S
+        sysbus <0x500A0000, +0x4000>  // USART0_NS
     }
     clockFrequency: 39000000
-    ReceiveIRQ -> nvic@9
-    TransmitIRQ -> nvic@10
+    ReceiveIRQ -> nvic@14
+    TransmitIRQ -> nvic@15
     RxDataAvailableRequest -> ldma@0x0040
     RxDataAvailableSingleRequest -> ldma@0x1040
     RxDataAvailableGpioSignal -> gpioPort@0x1201
@@ -18,31 +18,30 @@ usart0: UART.EFR32xG2_USART_0 @ {
     TxBufferLowSingleRequest -> ldma@0x1042
     TxEmptyRequest -> ldma@0x0044
 
-eusart0: UART.EFR32xG2_EUSART_2 @ {
+eusart0: UART.SiLabs_EUSART_2 @ {
         sysbus <0x4B010000, +0x4000>; // EUSART0_S
         sysbus <0x5B010000, +0x4000>  // EUSART0_NS
     }
     clockFrequency: 39000000
-    ReceiveIRQ -> nvic@11
-    TransmitIRQ -> nvic@12
+    ReceiveIRQ -> nvic@20
+    TransmitIRQ -> nvic@21
     RxFifoLevel -> ldma@0x00F0
     RxFifoLevelGpioSignal -> gpioPort@0x1202
     TxFifoLevel -> ldma@0x00F1
 
-eusart1: UART.EFR32xG2_EUSART_2 @ {
-        sysbus <0x400A0000, +0x4000>; // EUSART1_S
-        sysbus <0x500A0000, +0x4000>  // EUSART1_NS
+eusart1: UART.SiLabs_EUSART_2 @ {
+        sysbus <0x4008C000, +0x4000>; // EUSART1_S
+        sysbus <0x5008C000, +0x4000>  // EUSART1_NS
     }
     clockFrequency: 39000000
-    ReceiveIRQ -> nvic@13
-    TransmitIRQ -> nvic@14
+    ReceiveIRQ -> nvic@22
+    TransmitIRQ -> nvic@23
     RxFifoLevel -> ldma@0x0100
     RxFifoLevelGpioSignal -> gpioPort@0x1203
     TxFifoLevel -> ldma@0x0101
 
-radio: Wireless.EFR32xG24_Radio @ {
-        sysbus new Bus.BusMultiRegistration { address: 0x40098000; size: 0x4000; region: "hostmailbox" };
-        sysbus new Bus.BusMultiRegistration { address: 0x50098000; size: 0x4000; region: "hostmailbox_ns" };
+radio: Wireless.SiLabs_xG24_LPW @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x4009C000; size: 0x4000; region: "hostmailbox" };
         sysbus new Bus.BusMultiRegistration { address: 0xA8004000; size: 0x4000; region: "frc" };
         sysbus new Bus.BusMultiRegistration { address: 0xA800C000; size: 0x4000; region: "agc" };
         sysbus new Bus.BusMultiRegistration { address: 0xA8010000; size: 0x4000; region: "crc" };
@@ -52,6 +51,7 @@ radio: Wireless.EFR32xG24_Radio @ {
         sysbus new Bus.BusMultiRegistration { address: 0xA8020000; size: 0x4000; region: "rac" };
         sysbus new Bus.BusMultiRegistration { address: 0xA802C000; size: 0x4000; region: "rfmailbox" };
         sysbus new Bus.BusMultiRegistration { address: 0xAA000000; size: 0x4000; region: "bufc" };
+        sysbus new Bus.BusMultiRegistration { address: 0x5009C000; size: 0x4000; region: "hostmailbox_ns" };
         sysbus new Bus.BusMultiRegistration { address: 0xB8004000; size: 0x4000; region: "frc_ns" };
         sysbus new Bus.BusMultiRegistration { address: 0xB800C000; size: 0x4000; region: "agc_ns" };
         sysbus new Bus.BusMultiRegistration { address: 0xB8010000; size: 0x4000; region: "crc_ns" };
@@ -64,17 +64,18 @@ radio: Wireless.EFR32xG24_Radio @ {
     }
     ram: sram
     sequencer: seqcpu
+    sysrtc: sysrtc
     // Main CPU interrupts
-    AutomaticGainControlIRQ -> nvic@30
-    BufferControllerIRQ -> nvic@31
-    FrameControllerPrioritizedIRQ -> nvic@32
-    FrameControllerIRQ -> nvic@33
-    ModulatorAndDemodulatorIRQ -> nvic@34
-    ProtocolTimerIRQ -> nvic@35
-    RadioControllerRadioStateMachineIRQ -> nvic@36
-    RadioControllerSequencerIRQ -> nvic@37
-    HostMailboxIRQ -> nvic@38
-    SynthesizerIRQ -> nvic@39
+    AutomaticGainControlIRQ -> nvic@46
+    BufferControllerIRQ -> nvic@47
+    FrameControllerPrioritizedIRQ -> nvic@48
+    FrameControllerIRQ -> nvic@49
+    ModulatorAndDemodulatorIRQ -> nvic@50
+    ProtocolTimerIRQ -> nvic@51
+    RadioControllerRadioStateMachineIRQ -> nvic@52
+    RadioControllerSequencerIRQ -> nvic@53
+    HostMailboxIRQ -> nvic@54
+    SynthesizerIRQ -> nvic@55
     // Sequencer CPU interrupts
     SeqOffIRQ ->seqnvic@0
     SeqRxWarmIRQ ->seqnvic@1
@@ -97,24 +98,25 @@ radio: Wireless.EFR32xG24_Radio @ {
     SeqBufferControllerIRQ ->seqnvic@18
     SeqAutomaticGainControlIRQ ->seqnvic@19
     SeqProtocolTimerIRQ -> seqnvic@20
+    //SeqRtcIRQ -> seqnvic@21
     SeqSynthesizerIRQ -> seqnvic@22
     SeqRfMailboxIRQ -> seqnvic@23
 
-msc: Miscellaneous.SiLabs.EFR32xG2_MSC_3 @ {
+msc: Miscellaneous.SiLabs.SiLabs_MSC_3 @ {
         sysbus <0x40030000, +0x4000>; // MSC_S
         sysbus <0x50030000, +0x4000>  // MSC_NS
     }
     cpu: cpu
-    IRQ -> nvic@50
-    flashSize: 0x180000
+    IRQ -> nvic@66
+    flashSize: 0x320000
     flashPageSize: 0x2000
 
-gpioPort: GPIOPort.EFR32xG2_GPIO_3 @ {
+gpioPort: GPIOPort.SiLabs_GPIO_3 @ {
         sysbus <0x4003C000, +0x4000>; // GPIO_S
         sysbus <0x5003C000, +0x4000>  // GPIO_NS
     }
-    EvenIRQ -> nvic@26
-    OddIRQ -> nvic@25
+    EvenIRQ -> nvic@40
+    OddIRQ -> nvic@39
 
 bitclear: Miscellaneous.BitAccess
     address: 0x2000
@@ -125,7 +127,7 @@ bitset: Miscellaneous.BitAccess
     mode: BitAccessMode.Set
 
 sram: Memory.MappedMemory @ sysbus 0x20000000
-    size: 0x40000
+    size: 0x80000
 
 seqram: Memory.MappedMemory @ {
         sysbus 0xA0000000;
@@ -154,7 +156,6 @@ nvic: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
         cpu: cpu
     }
     -> cpu@0
-    systickFrequency: 39000000
 
 seqnvic: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
         address: 0xE000E000;
@@ -173,12 +174,12 @@ seqcpu: CPU.CortexM @ sysbus
     cpuId: 1
     IsHalted: true
 
-timer0: Timers.EFR32xG2_TIMER_1 @ {
+timer0: Timers.EFR32_Timer @ {
         sysbus <0x40048000, +0x4000>; // TIMER0_S
         sysbus <0x50048000, +0x4000>  // TIMER0_NS
     }
-    frequency: 20000000 //expected frequency for power manager HW tests
-    width: 16
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
     -> nvic@4
 
 timer1: Timers.EFR32_Timer @ {
@@ -189,13 +190,78 @@ timer1: Timers.EFR32_Timer @ {
     width: TimerWidth.Bit16
     -> nvic@5
 
-ldma: DMA.EFR32MG24_LDMA @ {
+timer2: Timers.EFR32_Timer @ {
+        sysbus <0x40050000, +0x4000>; // TIMER2_S
+        sysbus <0x50050000, +0x4000>  // TIMER2_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@6
+
+timer3: Timers.EFR32_Timer @ {
+        sysbus <0x40054000, +0x4000>; // TIMER3_S
+        sysbus <0x50054000, +0x4000>  // TIMER3_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@7
+
+timer4: Timers.EFR32_Timer @ {
+        sysbus <0x40058000, +0x4000>; // TIMER4_S
+        sysbus <0x50058000, +0x4000>  // TIMER4_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@8
+
+timer5: Timers.EFR32_Timer @ {
+        sysbus <0x4005C000, +0x4000>; // TIMER5_S
+        sysbus <0x5005C000, +0x4000>  // TIMER5_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@9
+
+timer6: Timers.EFR32_Timer @ {
+        sysbus <0x40060000, +0x4000>; // TIMER6_S
+        sysbus <0x50060000, +0x4000>  // TIMER6_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@10
+
+timer7: Timers.EFR32_Timer @ {
+        sysbus <0x40064000, +0x4000>; // TIMER7_S
+        sysbus <0x50064000, +0x4000>  // TIMER7_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@11
+
+
+timer8: Timers.EFR32_Timer @ {
+        sysbus <0x40068000, +0x4000>; // TIMER8_S
+        sysbus <0x50068000, +0x4000>  // TIMER8_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@12
+
+timer9: Timers.EFR32_Timer @ {
+        sysbus <0x4006C000, +0x4000>; // TIMER9_S
+        sysbus <0x5006C000, +0x4000>  // TIMER9_NS
+    }
+    frequency: 0x1000000 //bogus
+    width: TimerWidth.Bit16
+    -> nvic@13
+
+ldma: DMA.SiLabs_LDMA_0_3 @ {
         sysbus new Bus.BusMultiRegistration { address: 0x40040000; size: 0x4000; region: "ldma" };     // LDMA_S
         sysbus new Bus.BusMultiRegistration { address: 0x50040000; size: 0x4000; region: "ldma" };     // LDMA_NS
         sysbus new Bus.BusMultiRegistration { address: 0x40044000; size: 0x4000; region: "ldmaxbar" }; // LDMAXBAR_S
         sysbus new Bus.BusMultiRegistration { address: 0x50044000; size: 0x4000; region: "ldmaxbar" }  // LDMAXBAR_NS
     }
-    -> nvic@21
+    -> nvic@35
 
 wtimer0: Timers.EFR32_Timer @ {
         sysbus <0x4B004000, +0x4000>; // WDOG0_S
@@ -203,7 +269,7 @@ wtimer0: Timers.EFR32_Timer @ {
     }
     frequency: 0x1000000 //bogus
     width: TimerWidth.Bit32
-    -> nvic@42
+    -> nvic@58
 
 wtimer1: Timers.EFR32_Timer @ {
         sysbus <0x4B008000, +0x4000>; // WDOG1_S
@@ -211,113 +277,115 @@ wtimer1: Timers.EFR32_Timer @ {
     }
     frequency: 0x1000000 //bogus
     width: TimerWidth.Bit32
-    -> nvic@43
+    -> nvic@59
 
-deviceInformation: Miscellaneous.SiLabs.EFR32xG2_DeviceInformation @ sysbus 0x0FE08000
-    deviceFamily: DeviceFamily.EFR32MG24
+deviceInformation: Miscellaneous.SiLabs.SiLabs_DeviceInformation @ sysbus 0x0FE08000
+    deviceFamily: DeviceFamily.EFR32MG26
     deviceNumber: 0x1
     flashDevice: flash
     sramDevice: sram
 
-DCDC_IF: Python.PythonPeripheral @ sysbus 0x50094028
+DCDC_IF: Python.PythonPeripheral @ sysbus 0x50098028
     size: 0x4
     initable: true
     script: "request.value = 0xffffffff"
 
 flash: Memory.MappedMemory @ sysbus 0x08000000
-    size: 0x17E000
+    size: 0x31E000
 
-cmu: Miscellaneous.SiLabs.EFR32xG2_CMU_3 @ {
+cmu: Miscellaneous.SiLabs.SiLabs_CMU_3 @ {
         sysbus <0x40008000, +0x4000>; // CMU_S
         sysbus <0x50008000, +0x4000>  // CMU_NS
     }
     hfxo: hfxo
     dpll: dpll
 
-lfxo: Miscellaneous.SiLabs.EFR32xG2_LFXO_1 @ {
+lfxo: Miscellaneous.SiLabs.SiLabs_LFXO_1 @ {
         sysbus <0x40020000, +0x4000>; // LFXO_S
         sysbus <0x50020000, +0x4000>  // LFXO_NS
     }
 
-hfrco0: Miscellaneous.SiLabs.EFR32xG2_HFRCO_2 @ {
+hfrco0: Miscellaneous.SiLabs.SiLabs_HFRCO_2 @ {
         sysbus <0x40010000, +0x4000>; // HFRCO_S
         sysbus <0x50010000, +0x4000>  // HFRCO_NS
     }
 
-dpll: Miscellaneous.SiLabs.EFR32xG2_DPLL_1 @ {
+dpll: Miscellaneous.SiLabs.SiLabs_DPLL_1 @ {
         sysbus <0x4001C000, +0x4000>; // DPLL0_S
         sysbus <0x5001C000, +0x4000>  // DPLL0_NS
     }
 
-lfrco: Miscellaneous.SiLabs.EFR32xG2_LFRCO_2 @ {
+lfrco: Miscellaneous.SiLabs.SiLabs_LFRCO_2 @ {
         sysbus <0x40024000, +0x4000>; // LFRCO_S
         sysbus <0x50024000, +0x4000>  // LFRCO_NS
     }
 
-hfxo: Miscellaneous.SiLabs.EFR32xG2_HFXO_3 @ {
+hfxo: Miscellaneous.SiLabs.SiLabs_HFXO_3 @ {
         sysbus <0x4A004000, +0x4000>; // HFXO0_S
         sysbus <0x5A004000, +0x4000>  // HFXO0_NS
     }
-    startupDelayTicks: 3   //should remain <= 20 to pass early wakeup conditions
-    IRQ -> nvic@44
 
-hfrco1: Miscellaneous.SiLabs.EFR32xG2_HFRCO_2 @ {
+hfrcoem23: Miscellaneous.SiLabs.SiLabs_HFRCO_2 @ {
         sysbus <0x4A000000, +0x4000>; // HFRCOEM23_S
         sysbus <0x5A000000, +0x4000>  // HFRCOEM23_NS
     }
 
-emu: Miscellaneous.SiLabs.EFR32xG2_EMU_3 @ {
+emu: Miscellaneous.SiLabs.SiLabs_EMU_3 @ {
         sysbus <0x40004000, +0x4000>; // EMU_S
         sysbus <0x50004000, +0x4000>  // EMU_NS
     }
 
-syscfg: Miscellaneous.SiLabs.EFR32xG2_SYSCFG_3 @ {
+syscfg: Miscellaneous.SiLabs.SiLabs_SYSCFG_3 @ {
         sysbus <0x4007C000, +0x4000>; // SYSCFG_S
         sysbus <0x5007C000, +0x4000>  // SYSCFG_NS
     }
 
-sysrtc: Miscellaneous.SiLabs.EFR32xG2_SYSRTC_1 @ {
-        sysbus <0x400A8000, +0x4000>; // SYSRTC0_S
-        sysbus <0x500A8000, +0x4000>  // SYSRTC0_NS
+sysrtc: Timers.SiLabs_SYSRTC_1 @ {
+        sysbus <0x400AC000, +0x4000>; // SYSRTC0_S
+        sysbus <0x500AC000, +0x4000>  // SYSRTC0_NS
     }   
     frequency: 32768
-    IRQ -> nvic@67
+    IRQ -> nvic@83
+    AlternateIRQ -> seqnvic@21
 
-semailbox: Miscellaneous.SiLabs.EFR32xG2_SEMAILBOX_1 @ {
+semailbox: Miscellaneous.SiLabs.SiLabs_SEMAILBOX_1 @ {
         sysbus <0x4C000000, +0x4000>; // SEMAILBOX_S
         sysbus <0x5C000000, +0x4000>  // SEMAILBOX_NS
     }
-    RxIRQ -> nvic@65
-    TxIRQ -> nvic@66
+    RxIRQ -> nvic@81
+    TxIRQ -> nvic@82
 
-prs: Miscellaneous.SiLabs.EFR32xG2_PRS_3 @ {
+prs: Miscellaneous.SiLabs.SiLabs_PRS_6 @ {
         sysbus <0x40038000, +0x4000>; // PRS_S
         sysbus <0x50038000, +0x4000>  // PRS_NS
     }
     hfxo: hfxo
     sysrtc: sysrtc
+    lpw: radio
 
-radioaes: Miscellaneous.SiLabs.EFR32xG2_AES_1 @ {
+radioaes: Miscellaneous.SiLabs.SiLabs_AES_1 @ {
         sysbus <0x44000000, +0x4000>; // RADIOAES_S
         sysbus <0x54000000, +0x4000>  // RADIOAES_NS
     }
-    IRQ -> nvic@48
+    IRQ -> nvic@64
 
-flashuserdata: Miscellaneous.SiLabs.EFR32xG24_FlashUserData @ sysbus <0x0FE00000, +0x7F>
+flashuserdata: Miscellaneous.SiLabs.SiLabs_FlashUserData @ sysbus <0x0FE00000, +0x7F>
 
-itm : Miscellaneous.SiLabs.EFR32xG2_SLAB_ITM @ sysbus 0xE0000000
+itm : Miscellaneous.SiLabs.SiLabs_ITM @ sysbus 0xE0000000
 
 sysbus:
     init add:
         Tag <0x40000000, 0x40003FFF> "SCRATCHPAD_S"
         Tag <0x40004000, 0x40007FFF> "EMU_S"
         Tag <0x40008000, 0x4000BFFF> "CMU_S"
+        Tag <0x4000C000, 0x4000FFFF> "BURTC_S"
         Tag <0x40010000, 0x40013FFF> "HFRCO0_S"
         Tag <0x40018000, 0x4001BFFF> "FSRCO_S"
         Tag <0x4001C000, 0x4001FFFF> "DPLL0_S"
         Tag <0x40020000, 0x40023FFF> "LFXO_S"
         Tag <0x40024000, 0x40027FFF> "LFRCO_S"
         Tag <0x40028000, 0x4002BFFF> "ULFRCO_S"
+        Tag <0x4002C000, 0x4002FFFF> "KEYSCAN_S"
         Tag <0x40030000, 0x40033FFF> "MSC_S"
         Tag <0x40034000, 0x40037FFF> "ICACHE0_S"
         Tag <0x40038000, 0x4003BFFF> "PRS_S"
@@ -329,26 +397,40 @@ sysbus:
         Tag <0x40050000, 0x40053FFF> "TIMER2_S"
         Tag <0x40054000, 0x40057FFF> "TIMER3_S"
         Tag <0x40058000, 0x4005BFFF> "TIMER4_S"
-        Tag <0x4005C000, 0x4005FFFF> "USART0_S"
-        Tag <0x40064000, 0x40067FFF> "BURTC_S"
-        Tag <0x40068000, 0x4006BFFF> "I2C1_S"
-        Tag <0x40078000, 0x4007BFFF> "SYSCFG_S_CFGNS"
-        Tag <0x4007C000, 0x4007FFFF> "SYSCFG_S"
-        Tag <0x40080000, 0x40083FFF> "BURAM_S"
+        Tag <0x4005C000, 0x4005FFFF> "TIMER5_S"
+        Tag <0x40060000, 0x40063FFF> "TIMER6_S"
+        Tag <0x40064000, 0x40067FFF> "TIMER7_S"
+        Tag <0x40068000, 0x4006BFFF> "TIMER8_S"
+        Tag <0x4006C000, 0x4006FFFF> "TIMER9_S"
+        Tag <0x40070000, 0x40073FFF> "CHIPTESTCTRL_S"
+        Tag <0x40074000, 0x40077FFF> "DMEM0_S"
+        Tag <0x40078000, 0x4007BFFF> "DMEM1_S"
+        Tag <0x4007C000, 0x4007FFFF> "SYSCFG_S_CFGNS"
+        Tag <0x40080000, 0x40083FFF> "SYSCFG_S"
+        Tag <0x40084000, 0x40087FFF> "BURAM_S"
         Tag <0x40088000, 0x4008BFFF> "GPCRC_S"
-        Tag <0x40094000, 0x40097FFF> "DCDC_S"
-        Tag <0x40098000, 0x4009BFFF> "HOSTMAILBOX_S"
-        Tag <0x400A0000, 0x400A3FFF> "EUSART1_S"
-        Tag <0x400A8000, 0x400ABFFF> "SYSRTC0_S"
-        Tag <0x400B0000, 0x400B3FFF> "KEYSCAN_S"
-        Tag <0x400B4000, 0x400B7FFF> "DMEM_S"
-        Tag <0x44000000, 0x44003FFF> "RADIOAES_S"
+        Tag <0x4008C000, 0x4008FFFF> "EUSART1_S"
+        Tag <0x40090000, 0x40093FFF> "EUSART2_S"
+        Tag <0x40094000, 0x40097FFF> "EUSART3_S"
+        Tag <0x40098000, 0x4009BFFF> "DCDC_S"
+        Tag <0x4009C000, 0x4009FFFF> "HOSTMAILBOX_S"
+        Tag <0x400A0000, 0x400A3FFF> "USART0_S"
+        Tag <0x400A4000, 0x400A7FFF> "USART1_S"
+        Tag <0x400A8000, 0x400ABFFF> "USART2_S"
+        Tag <0x400AC000, 0x400AFFFF> "SYSRTC0_S"
+        Tag <0x400B0000, 0x400B3FFF> "I2C1_S"
+        Tag <0x400B4000, 0x400B7FFF> "I2C2_S"
+        Tag <0x400B8000, 0x400BBFFF> "I2C3_S"
+        Tag <0x400BC000, 0x400BFFFF> "LCD_S"
+        Tag <0x400C0000, 0x400C3FFF> "LCDRF_S"
+        Tag <0x44000000, 0x440007FF> "RADIOAES_S"
         Tag <0x44008000, 0x4400BFFF> "SMU_S"
         Tag <0x4400C000, 0x4400FFFF> "SMU_S_CFGNS"
         Tag <0x49000000, 0x49003FFF> "LETIMER0_S"
         Tag <0x49004000, 0x49007FFF> "IADC0_S"
         Tag <0x49008000, 0x4900BFFF> "ACMP0_S"
         Tag <0x4900C000, 0x4900FFFF> "ACMP1_S"
+        Tag <0x49020000, 0x49023FFF> "AMUXCP0_S"
         Tag <0x49024000, 0x49027FFF> "VDAC0_S"
         Tag <0x49028000, 0x4902BFFF> "VDAC1_S"
         Tag <0x49030000, 0x49033FFF> "PCNT0_S"
@@ -358,13 +440,27 @@ sysbus:
         Tag <0x4B004000, 0x4B007FFF> "WDOG0_S"
         Tag <0x4B008000, 0x4B00BFFF> "WDOG1_S"
         Tag <0x4B010000, 0x4B013FFF> "EUSART0_S"
-        Tag <0x4C000000, 0x4C003FFF> "SEMAILBOX_S"
+        Tag <0x4C000000, 0x4C00007F> "SEMAILBOX_S"
         Tag <0x4D000000, 0x4D003FFF> "MVP_S"
+        Tag <0xA8004000, 0xA8007FFF> "FRC_S"
+        Tag <0xA800C000, 0xA800FFFF> "AGC_S"
+        Tag <0xA8010000, 0xA8013FFF> "RFCRC_S"
+        Tag <0xA8014000, 0xA8017FFF> "MODEM_S"
+        Tag <0xA8018000, 0xA801BFFF> "SYNTH_S"
+        Tag <0xA801C000, 0xA801FFFF> "PROTIMER_S"
+        Tag <0xA8020000, 0xA8023FFF> "RAC_S"
+        Tag <0xA8024000, 0xA8027FFF> "RFSCRATCHPAD_S"
+        Tag <0xA802C000, 0xA802FFFF> "RFMAILBOX_S"
+        Tag <0xA8030000, 0xA8033FFF> "RFECA0_S"
+        Tag <0xA8034000, 0xA8037FFF> "RFECA1_S"
+        Tag <0xA8038000, 0xA803BFFF> "ECAIFADC_S"
+        Tag <0xAA000000, 0xAA003FFF> "BUFC_S"
         Tag <0x50000000, 0x50003FFF> "SCRATCHPAD_NS"
         Tag <0x50004000, 0x50007FFF> "EMU_NS"
         Tag <0x50008000, 0x5000BFFF> "CMU_NS"
+        Tag <0x5000C000, 0x5000FFFF> "BURTC_NS"
         Tag <0x50010000, 0x50013FFF> "HFRCO0_NS"
-        Tag <0x50018000, 0x5001BFFF> "FSRCO_NS"
+        Tag <0x50018000, 0x5001BFFF> "FSRCO0_NS"
         Tag <0x5001C000, 0x5001FFFF> "DPLL0_NS"
         Tag <0x50020000, 0x50023FFF> "LFXO_NS"
         Tag <0x50024000, 0x50027FFF> "LFRCO_NS"
@@ -380,26 +476,40 @@ sysbus:
         Tag <0x50050000, 0x50053FFF> "TIMER2_NS"
         Tag <0x50054000, 0x50057FFF> "TIMER3_NS"
         Tag <0x50058000, 0x5005BFFF> "TIMER4_NS"
-        Tag <0x5005C000, 0x5005FFFF> "USART0_NS"
-        Tag <0x50064000, 0x50067FFF> "BURTC_NS"
-        Tag <0x50068000, 0x5006BFFF> "I2C1_NS"
-        Tag <0x50078000, 0x5007BFFF> "SYSCFG_NS_CFGNS"
-        Tag <0x5007C000, 0x5007FFFF> "SYSCFG_NS"
-        Tag <0x50080000, 0x50083FFF> "BURAM_NS"
+        Tag <0x5005C000, 0x5005FFFF> "TIMER5_NS"
+        Tag <0x50060000, 0x50063FFF> "TIMER6_NS"
+        Tag <0x50064000, 0x50067FFF> "TIMER7_NS"
+        Tag <0x50068000, 0x5006BFFF> "TIMER8_NS"
+        Tag <0x5006C000, 0x5006FFFF> "TIMER9_NS"
+        Tag <0x50070000, 0x50073FFF> "CHIPTESTCTRL_NS"
+        Tag <0x50074000, 0x50077FFF> "DMEM0_NS"
+        Tag <0x50078000, 0x5007BFFF> "DMEM1_NS"
+        Tag <0x5007C000, 0x5007FFFF> "SYSCFG_NS_CFGNS"
+        Tag <0x50080000, 0x50083FFF> "SYSCFG_NS"
+        Tag <0x50084000, 0x50087FFF> "BURAM_NS"
         Tag <0x50088000, 0x5008BFFF> "GPCRC_NS"
-        Tag <0x50094000, 0x50097FFF> "DCDC_NS"
-        Tag <0x50098000, 0x5009BFFF> "HOSTMAILBOX_NS"
-        Tag <0x500A0000, 0x500A3FFF> "EUSART1_NS"
-        Tag <0x500A8000, 0x500ABFFF> "SYSRTC0_NS"
-        Tag <0x500B0000, 0x500B3FFF> "KEYSCAN_NS"
-        Tag <0x500B4000, 0x500B7FFF> "DMEM_NS"
-        Tag <0x54000000, 0x54003FFF> "RADIOAES_NS"
+        Tag <0x5008C000, 0x5008FFFF> "EUSART1_NS"
+        Tag <0x50090000, 0x50093FFF> "EUSART2_NS"
+        Tag <0x50094000, 0x50097FFF> "EUSART3_NS"
+        Tag <0x50098000, 0x5009BFFF> "DCDC_NS"
+        Tag <0x5009C000, 0x5009FFFF> "HOSTMAILBOX_NS"
+        Tag <0x500A0000, 0x500A3FFF> "USART0_NS"
+        Tag <0x500A4000, 0x500A7FFF> "USART1_NS"
+        Tag <0x500A8000, 0x500ABFFF> "USART2_NS"
+        Tag <0x500AC000, 0x500AFFFF> "SYSRTC0_NS"
+        Tag <0x500B0000, 0x500B3FFF> "I2C1_NS"
+        Tag <0x500B4000, 0x500B7FFF> "I2C2_NS"
+        Tag <0x500A8000, 0x500ABFFF> "I2C3_NS"
+        Tag <0x500BC000, 0x500BFFFF> "LCD_NS"
+        Tag <0x500C0000, 0x500C3FFF> "LCDRF_NS"
+        Tag <0x54000000, 0x540007FF> "RADIOAES_NS"
         Tag <0x54008000, 0x5400BFFF> "SMU_NS"
         Tag <0x5400C000, 0x5400FFFF> "SMU_NS_CFGNS"
-        Tag <0x59000000, 0x59003FFF> "LETIMER0_NS"
+        Tag <0x59000000, 0x59003FFF> "LETIMER_NS"
         Tag <0x59004000, 0x59007FFF> "IADC0_NS"
         Tag <0x59008000, 0x5900BFFF> "ACMP0_NS"
         Tag <0x5900C000, 0x5900FFFF> "ACMP1_NS"
+        Tag <0x59020000, 0x59023FFF> "AMUXCP0_NS"
         Tag <0x59024000, 0x59027FFF> "VDAC0_NS"
         Tag <0x59028000, 0x5902BFFF> "VDAC1_NS"
         Tag <0x59030000, 0x59033FFF> "PCNT0_NS"
@@ -409,26 +519,20 @@ sysbus:
         Tag <0x5B004000, 0x5B007FFF> "WDOG0_NS"
         Tag <0x5B008000, 0x5B00BFFF> "WDOG1_NS"
         Tag <0x5B010000, 0x5B013FFF> "EUSART0_NS"
-        Tag <0x5D000000, 0x5D003FFF> "MVP_NS"
-        Tag <0x54000000, 0x540007FF> "RADIOAES_NS"
         Tag <0x5C000000, 0x5C00007F> "SEMAILBOX_NS"
-        Tag <0xA8004000, 0xA8007FFF> "FRC"
-        Tag <0xA800C000, 0xA800FFFF> "AGC"
-        Tag <0xA8010000, 0xA8013FFF> "CRC"
-        Tag <0xA8014000, 0xA8017FFF> "MODEM"
-        Tag <0xA8018000, 0xA801BFFF> "SYNTH"
-        Tag <0xA801C000, 0xA801FFFF> "PROTIMER"
-        Tag <0xA8020000, 0xA8023FFF> "RAC"
-        Tag <0xA802C000, 0xA802FFFF> "RFMAILBOX"
-        Tag <0xAA000000, 0xAA003FFF> "BUFC"
+        Tag <0x5D000000, 0x5D003FFF> "MVP_NS"
         Tag <0xB8004000, 0xB8007FFF> "FRC_NS"
         Tag <0xB800C000, 0xB800FFFF> "AGC_NS"
-        Tag <0xB8010000, 0xB8013FFF> "CRC_NS"
+        Tag <0xB8010000, 0xB8013FFF> "RFCRC_NS"
         Tag <0xB8014000, 0xB8017FFF> "MODEM_NS"
         Tag <0xB8018000, 0xB801BFFF> "SYNTH_NS"
         Tag <0xB801C000, 0xB801FFFF> "PROTIMER_NS"
         Tag <0xB8020000, 0xB8023FFF> "RAC_NS"
+        Tag <0xB8024000, 0xB8027FFF> "RFSCRATCHPAD_NS"
         Tag <0xB802C000, 0xB802FFFF> "RFMAILBOX_NS"
+        Tag <0xB8030000, 0xB8033FFF> "RFECA0_NS"
+        Tag <0xB8034000, 0xB8037FFF> "RFECA1_NS"
+        Tag <0xB8038000, 0xB803BFFF> "ECAIFADC_NS"
         Tag <0xBA000000, 0xBA003FFF> "BUFC_NS"
         Tag <0xE0000000, 0xE0000FFF> "ITM"
         Tag <0x0FE00000, 0x0FE00009> "FLASH_USER_DATA"

--- a/platforms/cpus/silabs/sixG30x/sixG301.repl
+++ b/platforms/cpus/silabs/sixG30x/sixG301.repl
@@ -1,0 +1,520 @@
+i2c0: I2C.EFR32_I2CController @ {
+        sysbus <0x40200000, +0x4000>; // I2C0_NS
+        sysbus <0x50200000, +0x4000>  // I2C0_S
+    }
+    -> nvic@44
+
+gpioPort: GPIOPort.SiLabs_GPIO_8 @ {
+        sysbus <0x4083C000, +0x4000>; // GPIO_NS
+        sysbus <0x5083C000, +0x4000>  // GPIO_S
+    }
+    EvenIRQ -> nvic@43
+    OddIRQ -> nvic@42
+
+sram: Memory.MappedMemory @ {
+        sysbus 0x20000000; // SRAM_NS
+        sysbus 0x30000000; // SRAM_S
+        sysbus 0x00800000; // SRAM_ALIAS_NS (execute only)
+        sysbus 0x10800000 // SRAM_ALIAS_S (execute only)
+    }
+    size: 0x80000
+
+ahblpw0: Memory.MappedMemory @ {
+        sysbus 0xA0000000; // Port 0 Non Secure 
+        sysbus 0xA0100000; // Port 1 Non Secure 
+        sysbus 0xB0000000; // Port 0 Secure
+        sysbus 0xB0100000  // Port 1 Secure
+    }
+    size: 0x10000
+
+fswram: Memory.MappedMemory @ {
+        sysbus 0xA0010000;
+        sysbus 0xB0010000
+    }
+    size: 0x1000
+
+frcram: Memory.MappedMemory @ {
+        sysbus 0xA0011000;
+        sysbus 0xB0011000
+    }
+    size: 0x2000
+
+flash: Memory.MappedMemory @ {
+        sysbus 0x01000000; // FLASH_NS
+        sysbus 0x11000000  // FLASH_S
+    }
+    size: 0x400000
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    IRQ -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    nvic: nvic
+    cpuType: "cortex-m33"
+    cpuId: 0
+
+seqcpu: CPU.CV32E40P @ sysbus
+    hartId: 0
+    cpuType: "rv32imc_zicsr_zifencei_zba_zbb_zbs"
+    privilegedArchitecture: PrivilegedArchitecture.PrivUnratified
+    timeProvider: empty
+    IsHalted: true
+    init:
+        RegisterCustomCSR "MachineIntStatusH" 0x310 Machine    
+
+clic: IRQControllers.CoreLocalInterruptController @ { 
+        sysbus <0xF1000000, +0x4000>
+    } 
+    cpu: seqcpu
+    modeBits: 0
+
+rvconfig1: Miscellaneous.SiLabs.SiLabs_RvCfg_2 @ {
+        sysbus <0xA0248000, +0x4000>; // RVCFG1_NS
+        sysbus <0xB0248000, +0x4000>  // RVCFG1_S
+    }
+
+rvconfig2: Miscellaneous.SiLabs.SiLabs_RvCfg_2 @ {
+        sysbus <0xA024C000, +0x4000>; // RVCFG2_NS
+        sysbus <0xB024C000, +0x4000>  // RVCFG2_S
+    }
+
+radio: Wireless.SiLabs_xG301_LPW @ {
+        sysbus new Bus.BusMultiRegistration { address: 0xA0228000; size: 0x4000; region: "fswmailbox_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB0228000; size: 0x4000; region: "fswmailbox_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA022C000; size: 0x4000; region: "rfmailbox_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB022C000; size: 0x4000; region: "rfmailbox_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA0204000; size: 0x4000; region: "frc_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB0204000; size: 0x4000; region: "frc_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA020C000; size: 0x4000; region: "agc_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB020C000; size: 0x4000; region: "agc_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA0210000; size: 0x4000; region: "crc_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB0210000; size: 0x4000; region: "crc_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA0214000; size: 0x4000; region: "modem_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB0214000; size: 0x4000; region: "modem_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA0218000; size: 0x4000; region: "synth_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB0218000; size: 0x4000; region: "synth_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA021C000; size: 0x4000; region: "protimer_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB021C000; size: 0x4000; region: "protimer_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA0220000; size: 0x4000; region: "rac_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB0220000; size: 0x4000; region: "rac_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA0300000; size: 0x4000; region: "bufc_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB0300000; size: 0x4000; region: "bufc_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA3018000; size: 0x4000; region: "hostportal_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB3018000; size: 0x4000; region: "hostportal_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0xA3014000; size: 0x4000; region: "lpw0portal_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0xB3014000; size: 0x4000; region: "lpw0portal_s" }
+    }
+    sequencer: seqcpu
+    sequencerConfig: rvconfig1
+    // Main CPU interrupts
+    Lpw0PortalIRQ -> nvic@8
+    BufferControllerIRQ -> nvic@47
+    FrameControllerPrioritizedIRQ -> nvic@48
+    FrameControllerIRQ -> nvic@49
+    ProtocolTimerIRQ -> nvic@50
+    RadioControllerRadioStateMachineIRQ -> nvic@51
+    RadioControllerSequencerIRQ -> nvic@52
+    SynthesizerIRQ -> nvic@53
+    ModulatorAndDemodulatorIRQ -> nvic@56
+    AutomaticGainControlIRQ -> nvic@57
+    RfTimerIRQ -> nvic@58
+    // Sequencer CPU interrupts
+    SeqOffIRQ -> clic@26
+    SeqRxWarmIRQ -> clic@25
+    SeqRxSearchIRQ -> clic@24
+    SeqRxFrameIRQ -> clic@23
+    SeqRxWrapUpIRQ -> clic@22
+    SeqTxWarmIRQ -> clic@21
+    SeqTxIRQ -> clic@20
+    SeqTxWrapUpIRQ -> clic@19
+    SeqShutdownIRQ -> clic@18
+    SeqFrameControllerIRQ -> clic@16
+    SeqRadioControllerIRQ -> clic@17
+    SeqBufferControllerIRQ -> clic@13
+    SeqProtocolTimerIRQ -> clic@11
+    SeqModulatorAndDemodulatorIRQ -> clic@14
+    SeqAutomaticGainControlIRQ -> clic@12
+    SeqSynthesizerIRQ -> clic@9
+    SeqHostPortalIRQ -> clic@34
+    SeqRfMailboxIRQ -> clic@8
+
+seqacc: Miscellaneous.SiLabs.SiLabs_SEQACC_1 @ {
+        sysbus <0xA025C000, +0x4000>; // SEQACC_NS
+        sysbus <0xB025C000, +0x4000>  // SEQACC_S
+    }
+    frequency: 38400000
+    protocolTimer: radio
+    HostIRQ -> nvic@59
+    SequencerIRQ -> clic@27
+
+itm : Miscellaneous.SiLabs.SiLabs_ITM @ sysbus 0xE0000000
+
+timer0: Timers.SiLabs_TIMER_2 @ {
+        sysbus <0x40848000, +0x4000>; // TIMER0_NS
+        sysbus <0x50848000, +0x4000>  // TIMER0_S
+    }
+    frequency: 38400000
+    -> nvic@10
+
+timer1: Timers.SiLabs_TIMER_2 @ {
+        sysbus <0x4084C000, +0x4000>; // TIMER1_NS
+        sysbus <0x5084C000, +0x4000>  // TIMER1_S
+    }
+    frequency: 38400000
+    -> nvic@11
+
+timer2: Timers.SiLabs_TIMER_2 @ {
+        sysbus <0x40850000, +0x4000>; // TIMER2_NS
+        sysbus <0x50850000, +0x4000>  // TIMER2_S
+    }
+    frequency: 38400000
+    -> nvic@12
+
+timer3: Timers.SiLabs_TIMER_2 @ {
+        sysbus <0x40854000, +0x4000>; // TIMER3_NS
+        sysbus <0x50854000, +0x4000>  // TIMER3_S
+    }
+    frequency: 38400000
+    -> nvic@13
+
+cmu: Miscellaneous.SiLabs.SiLabs_CMU_8 @ {
+        sysbus <0x40804000, +0x4000>; // CMU_NS
+        sysbus <0x50804000, +0x4000>  // CMU_S
+    }
+
+hfxo: Miscellaneous.SiLabs.SiLabs_HFXO_5 @ {
+        sysbus <0x40104000, +0x4000>; // HFXO0_NS
+        sysbus <0x50104000, +0x4000>  // HFXO0_S
+    }
+    -> nvic@66    
+
+hfrcodpll: Miscellaneous.SiLabs.SiLabs_HFRCO_3 @ {
+        sysbus <0x40810000, +0x4000>; // HFRCO0_NS
+        sysbus <0x50810000, +0x4000>  // HFRCO0_S
+    }
+
+hfrcoem23: Miscellaneous.SiLabs.SiLabs_HFRCO_3 @ {
+        sysbus <0x40100000, +0x4000>; // HFRCOEM23_NS
+        sysbus <0x50100000, +0x4000>  // HFRCOEM23_S
+    }
+
+hydraram: Miscellaneous.SiLabs.SiLabs_HYDRARAM_1 @ {
+        sysbus <0x40808000, +0x4000>; // HOSTDMEM_NS
+        sysbus <0x50808000, +0x4000>  // HOSTDMEM_S
+    }
+
+dpll: Miscellaneous.SiLabs.SiLabs_DPLL_1 @ {
+        sysbus <0x4081C000, +0x4000>; // DPLL0_NS
+        sysbus <0x5081C000, +0x4000>  // DPLL0_S
+    }
+
+lfxo: Miscellaneous.SiLabs.SiLabs_LFXO_2 @ {
+        sysbus <0x40820000, +0x4000>; // LFXO_NS
+        sysbus <0x50820000, +0x4000>  // LFXO_S
+    }
+
+lfrco: Miscellaneous.SiLabs.SiLabs_LFRCO_4 @ {
+        sysbus <0x40824000, +0x4000>; // LFRCO_NS
+        sysbus <0x50824000, +0x4000>  // LFRCO_S
+    }
+
+socpll: Miscellaneous.SiLabs.SiLabs_SOCPLL_1 @ {
+        sysbus <0x40800000, +0x4000>; // SOCPLL_NS
+        sysbus <0x50800000, +0x4000>  // SOCPLL_S
+    }
+
+ksu: Miscellaneous.SiLabs.SiLabs_KSU_1 @ {
+        sysbus <0x4089C000, +0x4000>; // KSU_NS
+        sysbus <0x5089C000, +0x4000>  // KSU_S
+    }
+
+semailbox: Miscellaneous.SiLabs.SiLabs_SEMAILBOX_2 @ {
+        sysbus <0x42800000, +0x4000>; // SEMAILBOX_NS
+        sysbus <0x52800000, +0x4000>  // SEMAILBOX_S
+    }
+    flashSize: 0x400000
+    flashPageSize: 0x1000    
+    flashRegionSize: 0x8000
+    flashCodeRegionStart: 0x30000
+    flashCodeRegionEnd: 0x1E7FFF
+    flashDataRegionStart: 0x1E8000
+    ksu: ksu
+    RxIRQ -> nvic@1
+    TxIRQ -> nvic@2
+
+symcrypto: Miscellaneous.SiLabs.SiLabs_SYMCRYPTO_1 @ {
+        sysbus <0x41000000, +0x4000>; // SYMCRYPTO_NS
+        sysbus <0x51000000, +0x4000>  // SYMCRYPTO_S
+    }
+    ksu: ksu
+    -> nvic@74
+
+lpwaes: Miscellaneous.SiLabs.SiLabs_SYMCRYPTO_1 @ {
+        sysbus <0x41004000, +0x4000>; // LPWAES_NS
+        sysbus <0x51004000, +0x4000>  // LPWAES_S
+    }
+    ksu: ksu
+    -> nvic@75
+
+devinfo: Miscellaneous.SiLabs.SiLabs_DEVINFO_1 @ {
+        sysbus <0x0FE08000, +0x4000>; // DEVINFO_NS
+        sysbus <0x1FE08000, +0x4000>  // DEVINFO_S
+    }
+
+syscfg: Miscellaneous.SiLabs.SiLabs_SYSCFG_10 @ {
+        sysbus <0x40874000, +0x4000>; // SYSCFG_NS
+        sysbus <0x50874000, +0x4000>  // SYSCFG_S
+    }
+
+sysrtc: Timers.SiLabs_SYSRTC_2 @ {
+        sysbus <0xA3000000, +0x4000>; // SYSRTC0_NS
+        sysbus <0xB3000000, +0x4000>  // SYSRTC0_S
+    }
+    frequency: 32768
+    MsIRQ -> nvic@16
+    AppIRQ -> nvic@15
+    AppAlternateIRQ -> clic@10
+
+ldma: DMA.SiLabs_LDMA_3_3 @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40814000; size: 0x4000; region: "ldma_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50814000; size: 0x4000; region: "ldma_s" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40844000; size: 0x4000; region: "ldmaxbar_ns" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50844000; size: 0x4000; region: "ldmaxbar_s" }
+    }
+    Channel0IRQ -> nvic@31
+    Channel1IRQ -> nvic@32
+    Channel2IRQ -> nvic@33
+    Channel3IRQ -> nvic@34
+    Channel4IRQ -> nvic@35
+    Channel5IRQ -> nvic@36
+    Channel6IRQ -> nvic@37
+    Channel7IRQ -> nvic@38
+
+eusart0: UART.SiLabs_EUSART_4 @ {
+        sysbus <0x40208000, +0x4000>; // EUSART0_NS
+        sysbus <0x50208000, +0x4000>  // EUSART0_S
+    }
+    clockFrequency: 39000000 // RENODE-140: properly configure this
+    ReceiveIRQ -> nvic@17
+    TransmitIRQ -> nvic@18
+    RxFifoLevelRequest -> ldma@0x0090
+    RxFifoLevelGpioSignal -> gpioPort@0x1201
+    TxFifoLevelRequest -> ldma@0x0091
+
+eusart1: UART.SiLabs_EUSART_4 @ {
+        sysbus <0x40884000, +0x4000>; // EUSART1_NS
+        sysbus <0x50884000, +0x4000>  // EUSART1_S
+    }
+    clockFrequency: 39000000 // RENODE-140: properly configure this
+    ReceiveIRQ -> nvic@19
+    TransmitIRQ -> nvic@20
+    RxFifoLevelRequest -> ldma@0x0080
+    RxFifoLevelGpioSignal -> gpioPort@0x1202
+    TxFifoLevelRequest -> ldma@0x0081
+
+eusart2: UART.SiLabs_EUSART_4 @ {
+        sysbus <0x40888000, +0x4000>; // EUSART2_NS
+        sysbus <0x50888000, +0x4000>  // EUSART2_S
+    }
+    clockFrequency: 39000000 // RENODE-140: properly configure this
+    ReceiveIRQ -> nvic@21
+    TransmitIRQ -> nvic@22
+    RxFifoLevelRequest -> ldma@0x00F0
+    RxFifoLevelGpioSignal -> gpioPort@0x1203
+    TxFifoLevelRequest -> ldma@0x00F1
+
+wtimer0: Timers.SiLabs_TIMER_2 @ {
+        sysbus <0x40204000, +0x4000>; // WDOG0_NS
+        sysbus <0x50204000, +0x4000>  // WDOG0_S
+    }
+    frequency: 38400000
+    -> nvic@64
+
+wtimer1: Timers.SiLabs_TIMER_2 @ {
+        sysbus <0x40894000, +0x4000>; // WDOG1_NS
+        sysbus <0x50894000, +0x4000>  // WDOG1_S
+    }
+    frequency: 38400000
+    -> nvic@65
+
+semaphore0: Miscellaneous.SiLabs.SiLabs_SEMAPHORE_1 @ {
+        sysbus <0x4082C000, +0x4000>; // SEMAPHORE0_NS
+        sysbus <0x5082C000, +0x4000>  // SEMAPHORE0_S
+    }
+
+semaphore1: Miscellaneous.SiLabs.SiLabs_SEMAPHORE_1 @ {
+        sysbus <0x40830000, +0x4000>; // SEMAPHORE1_NS
+        sysbus <0x50830000, +0x4000>  // SEMAPHORE1_S
+    }
+
+sysbus:
+    init add:
+        Tag <0x0FE08000, 0x0FE0BFFF> "DEVINFO_NS"
+        Tag <0x40000000, 0x40003FFF> "LETIMER0_NS"
+        Tag <0x40004000, 0x40007FFF> "ADC0_NS"
+        Tag <0x40008000, 0x4000BFFF> "ACMP0_NS"
+        Tag <0x4000C000, 0x4000FFFF> "ACMP1_NS"
+        Tag <0x40010000, 0x40013FFF> "AMUXCP0_NS"
+        Tag <0x40040000, 0x40043FFF> "PCNT0_NS"
+        Tag <0x40100000, 0x40103FFF> "HFRCOEM23_NS"
+        Tag <0x40104000, 0x40107FFF> "HFXO0_NS"
+        Tag <0x40200000, 0x40203FFF> "I2C0_NS"
+        Tag <0x40204000, 0x40207FFF> "WDOG0_NS"
+        Tag <0x40208000, 0x4020BFFF> "EUSART0_NS"
+        Tag <0x40800000, 0x40803FFF> "SOCPLL_NS" 
+        Tag <0x40804000, 0x40807FFF> "CMU_NS"        
+        Tag <0x40808000, 0x4080BFFF> "HOSTDMEM_NS"       
+        Tag <0x40810000, 0x40813FFF> "HFRCO0_NS"
+        Tag <0x40814000, 0x40817FFF> "LDMA_NS"
+        Tag <0x40818000, 0x4081BFFF> "FSRCO_NS"
+        Tag <0x4081C000, 0x4081FFFF> "DPLL0_NS"
+        Tag <0x40820000, 0x40823FFF> "LFXO_NS"
+        Tag <0x40824000, 0x40827FFF> "LFRCO_NS"
+        Tag <0x40828000, 0x4082BFFF> "ULFRCO_NS"
+        Tag <0x4082C000, 0x4082FFFF> "SEMAPHORE0_NS"
+        Tag <0x40830000, 0x40833FFF> "SEMAPHORE1_NS"        
+        Tag <0x40834000, 0x40837FFF> "L1ICACHE0_NS"
+        Tag <0x40838000, 0x4083BFFF> "PRS_NS"
+        Tag <0x4083C000, 0x4083FFFF> "GPIO_NS"
+        Tag <0x40844000, 0x40847FFF> "LDMAXBAR_NS"
+        Tag <0x40848000, 0x4084BFFF> "TIMER0_NS"
+        Tag <0x4084C000, 0x4084FFFF> "TIMER1_NS"
+        Tag <0x40850000, 0x40853FFF> "TIMER2_NS"
+        Tag <0x40854000, 0x40857FFF> "TIMER3_NS"
+        Tag <0x40858000, 0x4085BFFF> "ETAMPDET_NS"
+        Tag <0x4085C000, 0x4085FFFF> "L2ICACHE_NS"
+        Tag <0x40860000, 0x40863FFF> "PIXELRZ0_NS"
+        Tag <0x40864000, 0x40867FFF> "BURTC_NS"
+        Tag <0x40868000, 0x4086BFFF> "I2C1_NS"
+        Tag <0x4086C000, 0x4086FFFF> "CHIPTESTCTRL_NS"
+        Tag <0x40870000, 0x40873FFF> "SYSCFG_NS_CFGNS"
+        Tag <0x40874000, 0x40877FFF> "SYSCFG_NS"
+        Tag <0x40878000, 0x4087BFFF> "BURAM_NS"
+        Tag <0x4087C000, 0x4087FFFF> "GPCRC_NS"
+        Tag <0x40880000, 0x40883FFF> "LEDDRV0_NS"
+        Tag <0x40884000, 0x40887FFF> "EUSART1_NS"
+        Tag <0x40888000, 0x4088BFFF> "EUSART2_NS"
+        Tag <0x4088C000, 0x4088FFFF> "PIXELRZ1_NS"
+        Tag <0x40890000, 0x40893FFF> "I2C2_NS"        
+        Tag <0x40894000, 0x40897FFF> "WDOG1_NS"
+        Tag <0x40898000, 0x4089BFFF> "RPA_NS"
+        Tag <0x4089C000, 0x4089FFFF> "KSU_NS"
+        Tag <0x41000000, 0x41003FFF> "SYMCRYPTO_NS"
+        Tag <0x41004000, 0x41007FFF> "LPWAES_NS"
+        Tag <0x41008000, 0x4100BFFF> "SMU_NS"
+        Tag <0x4100C000, 0x4100FFFF> "SMU_NS_CFGNS"  
+        Tag <0x42800000, 0x42803FFF> "SEMAILBOX_NS"
+        Tag <0x4FC00000, 0x4FC03FFF> "QSPI0_NS_MANUAL"
+        Tag <0xA0204000, 0xA0207FFF> "FRC_NS"
+        Tag <0xA020C000, 0xA020FFFF> "AGC_NS"
+        Tag <0xA0210000, 0xA0213FFF> "RFCRC_NS"
+        Tag <0xA0214000, 0xA0217FFF> "MODEM_NS"
+        Tag <0xA0218000, 0xA021BFFF> "SYNTH_NS"
+        Tag <0xA021C000, 0xA021FFFF> "PROTIMER_NS"
+        Tag <0xA0220000, 0xA0223FFF> "RAC_NS"
+        Tag <0xA0224000, 0xA0227FFF> "RFSCRATCHPAD_NS"
+        Tag <0xA0228000, 0xA022BFFF> "FSWMAILBOX_NS"
+        Tag <0xA022C000, 0xA022FFFF> "RFMAILBOX_NS"
+        Tag <0xA0230000, 0xA0233FFF> "RFECA0_NS"
+        Tag <0xA0234000, 0xA0237FFF> "RFECA1_NS"
+        Tag <0xA0238000, 0xA023BFFF> "ECAIFADC_NS"
+        Tag <0xA0240000, 0xA0243FFF> "HYDRARAMLPW1_NS"
+        Tag <0xA0244000, 0xA0247FFF> "SRWCMU_NS"
+        Tag <0xA0248000, 0xA024BFFF> "RVCFG1_NS"
+        Tag <0xA024C000, 0xA024FFFF> "RVCFG2_NS"
+        Tag <0xA0250000, 0xA0253FFF> "RFTIMER_NS"
+        Tag <0xA0254000, 0xA0257FFF> "DPLLLPW_NS"
+        Tag <0xA0258000, 0xA025BFFF> "HFRCOLPW_NS"
+        Tag <0xA025C000, 0xA025FFFF> "SEQACC_NS"
+        Tag <0xA0300000, 0xA0303FFF> "BUFC_NS"
+        Tag <0xA3000000, 0xA3003FFF> "SYSRTC0_NS"
+        Tag <0xA3004000, 0xA3007FFF> "SCRATCHPAD_NS"
+        Tag <0xA3008000, 0xA300BFFF> "EMU_NS"
+        Tag <0xA300C000, 0xA300FFFF> "EMU_NS_CFGNS_NS"
+        Tag <0xA3010000, 0xA3013FFF> "SEPORTAL_NS"
+        Tag <0xA3014000, 0xA3017FFF> "LPW0PORTAL_NS" 
+        Tag <0xA3018000, 0xA301BFFF> "HOSTPORTAL_NS"       
+        Tag <0x1FE08000, 0x1FE0BFFF> "DEVINFO_S"                           
+        Tag <0x50000000, 0x50003FFF> "LETIMER0_S"
+        Tag <0x50004000, 0x50007FFF> "ADC0_S"
+        Tag <0x50008000, 0x5000BFFF> "ACMP0_S"
+        Tag <0x5000C000, 0x5000FFFF> "ACMP1_S"
+        Tag <0x50010000, 0x50013FFF> "AMUXCP0_S"
+        Tag <0x50040000, 0x50043FFF> "PCNT0_S"
+        Tag <0x50100000, 0x50103FFF> "HFRCOEM23_S"
+        Tag <0x50104000, 0x50107FFF> "HFXO0_S"
+        Tag <0x50200000, 0x50203FFF> "I2C0_S"
+        Tag <0x50204000, 0x50207FFF> "WDOG0_S"
+        Tag <0x50208000, 0x5020BFFF> "EUSART0_S"
+        Tag <0x50800000, 0x50803FFF> "SOCPLL_S"                  
+        Tag <0x50804000, 0x50807FFF> "CMU_S"
+        Tag <0x50808000, 0x5080BFFF> "HOSTDMEM_S"           
+        Tag <0x50810000, 0x50813FFF> "HFRCO0_S"
+        Tag <0x50814000, 0x50817FFF> "LDMA_S"
+        Tag <0x50818000, 0x5081BFFF> "FSRCO_S"
+        Tag <0x5081C000, 0x5081FFFF> "DPLL0_S"
+        Tag <0x50820000, 0x50823FFF> "LFXO_S"
+        Tag <0x50824000, 0x50827FFF> "LFRCO_S"
+        Tag <0x50828000, 0x5082BFFF> "ULFRCO_S"
+        Tag <0x5082C000, 0x5082FFFF> "SEMAPHORE0_S"
+        Tag <0x50830000, 0x50833FFF> "SEMAPHORE1_S"         
+        Tag <0x50834000, 0x50837FFF> "L1ICACHE0_S"
+        Tag <0x50838000, 0x5083BFFF> "PRS_S"
+        Tag <0x5083C000, 0x5083FFFF> "GPIO_S"
+        Tag <0x50844000, 0x50847FFF> "LDMAXBAR_S"
+        Tag <0x50848000, 0x5084BFFF> "TIMER0_S"
+        Tag <0x5084C000, 0x5084FFFF> "TIMER1_S"
+        Tag <0x50850000, 0x50853FFF> "TIMER2_S"
+        Tag <0x50854000, 0x50857FFF> "TIMER3_S"
+        Tag <0x50858000, 0x5085BFFF> "ETAMPDET_S"
+        Tag <0x5085C000, 0x5085FFFF> "L2ICACHE_S"
+        Tag <0x50860000, 0x50863FFF> "PIXELRZ0_S"
+        Tag <0x50864000, 0x50867FFF> "BURTC_S"
+        Tag <0x50868000, 0x5086BFFF> "I2C1_S"
+        Tag <0x5086C000, 0x5086FFFF> "CHIPTESTCTRL_S"
+        Tag <0x50870000, 0x50873FFF> "SYSCFG_S_CFGNS"
+        Tag <0x50874000, 0x50877FFF> "SYSCFG_S"
+        Tag <0x50878000, 0x5087BFFF> "BURAM_S"
+        Tag <0x5087C000, 0x5087FFFF> "GPCRC_S"
+        Tag <0x50880000, 0x50883FFF> "LEDDRV0_S"        
+        Tag <0x50884000, 0x50887FFF> "EUSART1_S"
+        Tag <0x50888000, 0x5088BFFF> "EUSART2_S"
+        Tag <0x5088C000, 0x5088FFFF> "PIXELRZ1_S" 
+        Tag <0x50890000, 0x50893FFF> "I2C2_S"                  
+        Tag <0x50894000, 0x50897FFF> "WDOG1_S"
+        Tag <0x50898000, 0x5089BFFF> "RPA_S"
+        Tag <0x5089C000, 0x5089FFFF> "KSU_S"
+        Tag <0x51000000, 0x51003FFF> "SYMCRYPTO_S"
+        Tag <0x51004000, 0x51007FFF> "LPWAES_S"
+        Tag <0x51008000, 0x5100BFFF> "SMU_S"
+        Tag <0x5100C000, 0x5100FFFF> "SMU_S_CFGNS"
+        Tag <0x52800000, 0x52803FFF> "SEMAILBOX_S"
+        Tag <0xB0204000, 0xB0207FFF> "FRC_S"
+        Tag <0xB020C000, 0xB020FFFF> "AGC_S"
+        Tag <0xB0210000, 0xB0213FFF> "RFCRC_S"
+        Tag <0xB0214000, 0xB0217FFF> "MODEM_S"
+        Tag <0xB0218000, 0xB021BFFF> "SYNTH_S"
+        Tag <0xB021C000, 0xB021FFFF> "PROTIMER_S"
+        Tag <0xB0220000, 0xB0223FFF> "RAC_S"
+        Tag <0xB0224000, 0xB0227FFF> "RFSCRATCHPAD_S"
+        Tag <0xB0228000, 0xB022BFFF> "FSWMAILBOX_S"
+        Tag <0xB022C000, 0xB022FFFF> "RFMAILBOX_S"
+        Tag <0xB0230000, 0xB0233FFF> "RFECA0_S"
+        Tag <0xB0234000, 0xB0237FFF> "RFECA1_S"
+        Tag <0xB0238000, 0xB023BFFF> "ECAIFADC_S"
+        Tag <0xB0240000, 0xB0243FFF> "HYDRARAMLPW1_S"
+        Tag <0xB0244000, 0xB0247FFF> "SRWCMU_S"
+        Tag <0xB0248000, 0xB024BFFF> "RVCFG1_S"
+        Tag <0xB024C000, 0xB024FFFF> "RVCFG2_S"
+        Tag <0xB0250000, 0xB0253FFF> "RFTIMER_S"
+        Tag <0xB0254000, 0xB0257FFF> "DPLLLPW_S"
+        Tag <0xB0258000, 0xB025BFFF> "HFRCOLPW_S"
+        Tag <0xB025C000, 0xB025FFFF> "SEQACC_S"
+        Tag <0xB0300000, 0xB0303FFF> "BUFC_S"
+        Tag <0xB3000000, 0xB3003FFF> "SYSRTC0_S"
+        Tag <0xB3004000, 0xB3007FFF> "SCRATCHPAD_S"
+        Tag <0xB3008000, 0xB300BFFF> "EMU_S"
+        Tag <0xB300C000, 0xB300FFFF> "EMU_S_CFGNS"
+        Tag <0xB3010000, 0xB3013FFF> "SEPORTAL_S"
+        Tag <0xB3014000, 0xB3017FFF> "LPW0PORTAL_S" 
+        Tag <0xB3018000, 0xB301BFFF> "HOSTPORTAL_S"

--- a/scripts/complex/silabs/twonode_demo.resc
+++ b/scripts/complex/silabs/twonode_demo.resc
@@ -27,9 +27,12 @@ macro reset
 mach create "node1"
 machine LoadPlatformDescription "platforms/boards/silabs/brd4186c.repl"
 runMacro $reset
-emulation CreateServerSocketTerminal 3451 "cli_node1"
+emulation CreateServerSocketTerminal 3451 "cli_node1" false
 connector Connect sysbus.eusart0 cli_node1
 connector Connect sysbus.radio wireless
+# Optional: Create a debug adapter for packet trace
+# emulation CreateServerSocketTerminal 3551 "dch_term_node1" false
+# emulation CreatePacketTraceDebugAdapter sysbus.radio dch_term_node1 "dch_node1"
 logLevel 3
 ### Debug
 # Uncomment to enable debugging of main CPU
@@ -45,9 +48,12 @@ mach clear
 mach create "node2"
 machine LoadPlatformDescription "platforms/boards/silabs/brd4186c.repl"
 runMacro $reset
-emulation CreateServerSocketTerminal 3452 "cli_node2"
+emulation CreateServerSocketTerminal 3452 "cli_node2" false
 connector Connect sysbus.eusart0 cli_node2
 connector Connect sysbus.radio wireless
+# Optional: Create a debug adapter for packet trace
+# emulation CreateServerSocketTerminal 3552 "dch_term_node2" false
+# emulation CreatePacketTraceDebugAdapter sysbus.radio dch_term_node2 "dch_node2"
 logLevel 3
 ### Debug
 # Uncomment to enable debugging of main CPU

--- a/tests/peripherals/SiLabs/EUSART.robot
+++ b/tests/peripherals/SiLabs/EUSART.robot
@@ -1,0 +1,372 @@
+*** Variables ***
+${FREQUENCY}                    39000000
+# The EUSART_IP variable must be set from command line  
+# For example: renode-test --variable EUSART_IP:<EUSART IP to being tested> this_test.robot
+${EUSART_IP}                    UART.SiLabs_EUSART_2
+${REPL_STRING}=                 SEPARATOR=
+...  """                                            ${\n}
+...  eusart: ${EUSART_IP} @ sysbus <0x0, +0x4000>   ${\n}
+...  ${SPACE*4}clockFrequency: ${FREQUENCY}         ${\n}
+...  """
+
+# Registers
+${EN_REG}                     0x0004
+${CFG0_REG}                   0x0008
+${CFG1_REG}                   0x000C
+${CFG2_REG}                   0x0010
+${FRAMECFG_REG}               0x0014
+${DTXDATACFG_REG}             0x0018
+${IRHFCFG_REG}                0x001C
+${IRLFCFG_REG}                0x0020
+${TIMINGCFG_REG}              0x0024
+${STARTFRAMECFG_REG}          0x0028
+${SIGFRAMECFG_REG}            0x002C
+${CLKDIV_REG}                 0x0030
+${TRIGCTRL_REG}               0x0034
+${CMD_REG}                    0x0038
+${RXDATA_REG}                 0x003C
+${RXDATAP_REG}                0x0040
+${TXDATA_REG}                 0x0044
+${STATUS_REG}                 0x0048
+${IF_REG}                     0x004C
+${IEN_REG}                    0x0050
+${SYNCBUSY_REG}               0x0054
+${DALICFG_REG}                0x0058
+${TEST_REG}                   0x0100
+
+${IF_CLR_REG}                 0x204C
+${IEN_CLR_REG}                0x2050
+${STATUS_CLR_REG}             0x2048
+
+
+# Bit fields for EUSART STATUS 
+${_EUSART_STATUS_RESETVALUE}          0x00003040UL                 #< Default value for EUSART_STATUS
+${_EUSART_STATUS_MASK}                0x031F31FBUL                 #< Mask for EUSART_STATUS
+${EUSART_STATUS_RXENS}                0x1                          #< Receiver Enable Status
+${_EUSART_STATUS_RXENS_SHIFT}         0                            #< Shift value for EUSART_RXENS
+${_EUSART_STATUS_RXENS_MASK}          0x1                          #< Bit mask for EUSART_RXENS
+${_EUSART_STATUS_RXENS_DEFAULT}       0x00000000                   #< Mode DEFAULT for EUSART_STATUS
+${EUSART_STATUS_RXENS_DEFAULT}        0x00000000                   #< Shifted mode DEFAULT for EUSART_STATUS
+${EUSART_STATUS_TXENS}                0x2                          #< Transmitter Enable Status
+${_EUSART_STATUS_TXENS_SHIFT}         1                            #< Shift value for EUSART_TXENS
+${_EUSART_STATUS_TXENS_MASK}          0x2                          #< Bit mask for EUSART_TXENS
+${_EUSART_STATUS_TXENS_DEFAULT}       0x00000000                   #< Mode DEFAULT for EUSART_STATUS
+
+# Bit fields for EUSART IF 
+${_EUSART_IF_MASK}                    0x030D3FFF                   #< Mask for EUSART_IF
+${_EUSART_IF_CSWU_MASK}               0x00010000                   #< Bit mask for EUSART_CSWU
+${EUSART_IF_TXC}                      0x1                          #< TX Complete Interrupt Flag                 
+${EUSART_IF_RXFL}                     0x3                          #< RX FIFO Level Interrupt Flag                
+${EUSART_IF_STARTF}                   0x1000000                    #< Start Frame Interrupt Flag
+
+# Bit fields for EUSART SYNCBUSY 
+${_EUSART_SYNCBUSY_RESETVALUE}        0x00000000                   #< Default value for EUSART_SYNCBUSY           
+${_EUSART_SYNCBUSY_MASK}              0x00000FFF                   #< Mask for EUSART_SYNCBUSY                    
+${EUSART_SYNCBUSY_DIV}                0x1                          #< SYNCBUSY for DIV in CLKDIV                  
+${_EUSART_SYNCBUSY_DIV_SHIFT}         0                            #< Shift value for EUSART_DIV                  
+${_EUSART_SYNCBUSY_DIV_MASK}          0x1                          #< Bit mask for EUSART_DIV                     
+${_EUSART_SYNCBUSY_DIV_DEFAULT}       0x00000000                   #< Mode DEFAULT for EUSART_SYNCBUS
+
+# test specific vars
+${NUM_SAMPLES}                        0x4
+${EXPECTED_START_STATUS_TX}           0x3042  
+${EXPECTED_END_STATUS_TX}             0x3062  
+${EXPECTED_START_IF_TX}               0x2  
+${EXPECTED_END_IF_TX}                 0x3  
+${EXPECTED_START_STATUS_RX}           0x3041
+${EXPECTED_START_IF_RX}               0x0
+${EXPECTED_END_IF_RX}                 0x4
+
+${CFG1_RXWATERMARK_2}                 0x08000000
+${CFG1_RXWATERMARK_3}                 0x10000000
+${EXPECTED_START_STATUS_RX_MULTI}     0x3041  
+${EXPECTED_END_STATUS_RX_MULTI}       0x30C1  
+
+*** Keywords ***
+Create Machine
+    Execute Command             mach create "test"
+    Execute Command             machine LoadPlatformDescriptionFromString ${REPL_STRING}
+
+Enable Rx Command
+    Execute Command             sysbus.eusart WriteDoubleWord ${CMD_REG} 0x1
+
+Disable Rx Command
+    Execute Command             sysbus.eusart WriteDoubleWord ${CMD_REG} 0x2
+
+Enable Tx Command
+    Execute Command             sysbus.eusart WriteDoubleWord ${CMD_REG} 0x4
+
+Enable Rx Tx Command
+    Execute Command             sysbus.eusart WriteDoubleWord ${CMD_REG} 0x5
+
+Disable Tx Command
+    Execute Command             sysbus.eusart WriteDoubleWord ${CMD_REG} 0x8
+
+Disable RXBLOCK Command
+    Execute Command             sysbus.eusart WriteDoubleWord ${CMD_REG} 0x10
+
+All Off Command
+    Execute Command             sysbus.eusart WriteDoubleWord ${CMD_REG} 0x0
+
+Assert Receive IRQ Is Set
+    ${irqState}=                    Execute Command  sysbus.eusart ReceiveIRQ
+    Should Contain                  ${irqState}  GPIO: set
+
+Assert Receive IRQ Is Unset
+    ${irqState}=                    Execute Command  sysbus.eusart ReceiveIRQ
+    Should Contain                  ${irqState}  GPIO: unset
+
+Assert Transmit IRQ Is Set
+    ${irqState}=                    Execute Command  sysbus.eusart TransmitIRQ
+    Should Contain                  ${irqState}  GPIO: set
+
+Assert Transmit IRQ Is Unset
+    ${irqState}=                    Execute Command  sysbus.eusart TransmitIRQ
+    Should Contain                  ${irqState}  GPIO: unset
+   
+*** Test Cases ***
+EUSART IP Selection
+    Log to Console                EUSART_${EUSART_IP} TESTSUITE
+    Log to Console                ${REPL_STRING}
+    
+Enable Rx Only
+    Create Machine
+    Enable Rx Command    
+    ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register RXEN only 
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_RXENS_MASK}",16)) #check RXENS 
+    ${check_val}                evaluate  hex(${EUSART_STATUS_RXENS})               
+    Should Be Equal As Integers   ${read_val}  ${check_val}    
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_TXENS_MASK}",16)) #check TXENS
+    ${check_val}                evaluate  0x0                
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    Disable Rx Command
+
+Enable Tx Only
+    Create Machine
+    Enable Tx Command
+    ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_RXENS_MASK}",16)) #check RXENS 
+    ${check_val}                evaluate  0x0               
+    Should Be Equal As Integers   ${read_val}  ${check_val}      
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_TXENS_MASK}",16)) #check TXENS 
+    ${check_val}                evaluate  hex(${EUSART_STATUS_TXENS})                 
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    Disable Tx Command
+
+Enable Rx Tx
+    Create Machine
+    Enable Rx Tx Command
+    ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_RXENS_MASK}",16)) #check RXENS 
+    ${check_val}                evaluate  hex(${EUSART_STATUS_RXENS})               
+    Should Be Equal As Integers   ${read_val}  ${check_val}      
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_TXENS_MASK}",16)) #check TXENS 
+    ${check_val}                evaluate  hex(${EUSART_STATUS_TXENS})                 
+    Should Be Equal As Integers   ${read_val}  ${check_val}    
+    All Off Command
+
+Enables Disabled
+    Create Machine
+    All Off Command
+    ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_RXENS_MASK}",16)) #check RXENS 
+    ${check_val}                evaluate  0x0               
+    Should Be Equal As Integers   ${read_val}  ${check_val}      
+    ${read_val}                 evaluate  hex(${statusState} & int("${_EUSART_STATUS_TXENS_MASK}",16)) #check TXENS 
+    ${check_val}                evaluate  0x0                 
+    Should Be Equal As Integers   ${read_val}  ${check_val}  
+
+Interrupts 
+    Create Machine
+    Enable Rx Tx Command
+    ${check_val}                  evaluate  hex(2) #TXFL goes high as soon as there is space in the Tx FIFO.
+    ${read_val}=                  Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    #Test reset value;
+    Should Be Equal As Integers   ${read_val}  ${check_val} 
+   
+    #set sync busy reg
+    Execute Command               sysbus.eusart WriteDoubleWord ${SYNCBUSY_REG} ${_EUSART_SYNCBUSY_MASK }
+    #check setting interrupt flags
+    ${flag}                       evaluate  hex(int("${_EUSART_IF_MASK}",16) & ~int("${_EUSART_IF_CSWU_MASK}",16))  #EM2 mode
+    # ${flag}                     evaluate  hex(int("${_EUSART_IF_MASK}",16))
+    ${check_val}                  evaluate  hex(63)  #cfg for other modes not set so upper bits are usually not set 
+    Execute Command               sysbus.eusart WriteDoubleWord ${IF_REG} ${flag}
+    ${read_val}=                  Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+
+    #check intEnable 
+    ${flag}                       evaluate  hex( int("${EUSART_IF_RXFL}",16) | int("${EUSART_IF_STARTF}",16) | int("${EUSART_IF_TXC}",16) )
+    Execute Command               sysbus.eusart WriteDoubleWord ${IEN_REG} ${flag}
+    ${read_val}=                  Execute Command  sysbus.eusart ReadDoubleWord ${IEN_REG}
+    ${check_val}                  evaluate  hex(3)  #cfg for other modes not set so upper bits are usually not set 
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+
+    #check intDisable
+    ${check_val}                  evaluate  hex(0)
+    Execute Command               sysbus.eusart WriteDoubleWord ${IEN_CLR_REG} ${flag}
+    ${read_val}=                  Execute Command  sysbus.eusart ReadDoubleWord ${IEN_REG}
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+
+    #checkIntClear
+    ${check_val}                  evaluate  hex(3) 
+    ${flag}                       evaluate  hex(${${_EUSART_IF_MASK} } & ~(${flag} | 3))
+    Execute Command               sysbus.eusart WriteDoubleWord ${IF_CLR_REG} ${flag}
+    ${read_val}=                  Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+
+    #clear sync busy reg
+    Execute Command               sysbus.eusart WriteDoubleWord ${SYNCBUSY_REG} 0x00000000
+    Disable RXBLOCK Command
+
+Asynchronous TX 
+    Create Machine
+    ${data_list}=                       evaluate  random.sample(range(1, 11), ${NUM_SAMPLES})  #select a random number between 1 and 10 inclusive
+    
+    Enable Tx Command
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG} #Read STATUS register TXEN only 
+    ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+    Should Be Equal As Integers  ${statusState}  ${EXPECTED_START_STATUS_TX}
+
+    FOR  ${data}  IN  @{data_list}
+        ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+        ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG} #Read STATUS register TXEN only 
+        Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_TX}
+        Execute Command               sysbus.eusart WriteDoubleWord ${TXDATA_REG} ${data}
+        ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+        ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG} #Read STATUS register TXEN only
+        Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_END_IF_TX}
+        Should Be Equal As Integers  ${statusState}  ${expected_end_status_tx}        
+        #clear tx complete Interupt flag when new frame is available
+        Execute Command  sysbus.eusart WriteDoubleWord ${IF_REG} 0x2
+        #clear tx complete status (software would do)
+    END 
+    Disable Tx Command
+
+Asynchronous RX
+    Create Machine
+    ${data_list}=                       evaluate  random.sample(range(97, 108), ${NUM_SAMPLES})  #select a random number between chars a-k in ascii
+    
+    Enable Rx Command
+
+    FOR  ${data}  IN  @{data_list}
+        ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG} #Read STATUS register TXEN only 
+        ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+
+        ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG} #Read STATUS register TXEN only 
+        ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+        Should Be Equal As Integers  ${statusState}  ${_expected_start_status_rx}
+        Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_RX}
+
+        Execute Command  sysbus.eusart WriteChar ${data}
+
+        ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATA_REG} 
+        Should Be Equal As Integers  ${rxData}  ${data}
+        ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG} #Read STATUS register TXEN only 
+        ${statusState}=             Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG} #Read STATUS register TXEN only 
+    END
+    
+    Disable Rx Command
+
+RX DATA PEAK
+    Create Machine
+    ${data_list}=                       evaluate  random.sample(range(97, 108), ${NUM_SAMPLES})  #select a random number between chars a-k in ascii
+    
+    Enable Rx Command
+
+    # Write data into receive pipeline fifos
+    Execute Command  sysbus.eusart WriteChar ${data_list}[0]
+
+    # Read fifo slot twice to ensure RXDATAP does not pop from the fifo
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATAP_REG} 
+    Should Be Equal As Integers  ${rxData}  ${data_list}[0]
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATAP_REG} 
+    Should Be Equal As Integers  ${rxData}  ${data_list}[0]
+    Disable Rx Command
+
+Asynchronous RX Multiframe
+    Create Machine
+    ${data_list}=                       evaluate  random.sample(range(97, 108), ${NUM_SAMPLES})  #select a random number between chars a-k in ascii
+
+    Enable Rx Command
+    
+    # Assert rxflif is zero to start
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_RX}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_START_STATUS_RX_MULTI} 
+
+    # Write data into receive pipeline fifos
+    Execute Command  sysbus.eusart WriteChar ${data_list}[0]
+
+    # Check RXFLIF is set as watermark is set to 1 currently
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_END_IF_RX} 
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_END_STATUS_RX_MULTI} 
+
+    # Reset interupt flag by emptying fifo by popping the single data element inserted
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATA_REG} 
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_RX}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_START_STATUS_RX_MULTI} 
+
+    # Reconfigure fifo watermark to 2
+    Execute Command  sysbus.eusart WriteDoubleWord ${CFG1_REG} ${CFG1_RXWATERMARK_2}
+
+    # Write single data element into fifo and ensure RXFLIF is not set
+    Execute Command  sysbus.eusart WriteChar ${data_list}[0]
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_START_STATUS_RX_MULTI} 
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_RX}
+
+    # Write second data element into fifo and ensure RXFLIF is set
+    Execute Command  sysbus.eusart WriteChar ${data_list}[1]
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_END_IF_RX}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_END_STATUS_RX_MULTI} 
+
+    # Reset interupt flag by emptying fifo by popping the both data elements inserted
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATA_REG} 
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATA_REG} 
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_RX}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_START_STATUS_RX_MULTI} 
+
+    # Reconfigure fifo watermark to 3
+    Execute Command  sysbus.eusart WriteDoubleWord ${CFG1_REG} ${CFG1_RXWATERMARK_3} 
+
+    # Write single data element into fifo and ensure RXFLIF is not set
+    Execute Command  sysbus.eusart WriteChar ${data_list}[0]
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_RX}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_START_STATUS_RX_MULTI} 
+
+    # Write second data element into fifo and ensure RXFLIF is not set
+    Execute Command  sysbus.eusart WriteChar ${data_list}[1]
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_START_IF_RX}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_START_STATUS_RX_MULTI} 
+
+    # Write third data element into fifo and ensure RXFLIF is set
+    Execute Command  sysbus.eusart WriteChar ${data_list}[2]
+    ${StatusState}=       Execute Command  sysbus.eusart ReadDoubleWord ${STATUS_REG}
+    ${InteruptFlagState}=       Execute Command  sysbus.eusart ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers  ${InteruptFlagState}  ${EXPECTED_END_IF_RX}
+    Should Be Equal As Integers  ${StatusState}  ${EXPECTED_END_STATUS_RX_MULTI} 
+
+    # Read out all data elements from fifo and ensure they are correct values
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATA_REG}
+    Should Be Equal As Integers  ${rxData}  ${data_list}[0]
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATA_REG}
+    Should Be Equal As Integers  ${rxData}  ${data_list}[1]
+    ${rxData}=             Execute Command  sysbus.eusart ReadDoubleWord ${RXDATA_REG}
+    Should Be Equal As Integers  ${rxData}  ${data_list}[2]
+
+    Disable Rx Command
+

--- a/tests/peripherals/SiLabs/LDMA_3.robot
+++ b/tests/peripherals/SiLabs/LDMA_3.robot
@@ -1,0 +1,171 @@
+*** Variables ***
+${REPL_STRING}=                 SEPARATOR=
+...  """                                                                                                        
+...  ldma: DMA.SiLabs_LDMA_3_3 @ {                                                                               ${\n}
+...  ${SPACE*8}sysbus new Bus.BusMultiRegistration { address: 0x40814000; size: 0x4000; region: "ldma_ns" };     ${\n}
+...  ${SPACE*8}sysbus new Bus.BusMultiRegistration { address: 0x50814000; size: 0x4000; region: "ldma_s" };      ${\n}
+...  ${SPACE*8}sysbus new Bus.BusMultiRegistration { address: 0x40844000; size: 0x4000; region: "ldmaxbar_ns" }; ${\n}
+...  ${SPACE*8}sysbus new Bus.BusMultiRegistration { address: 0x50844000; size: 0x4000; region: "ldmaxbar_s" }   ${\n}
+...  ${SPACE*8}}                                                                                                 ${\n}
+...  """
+
+# Registers
+${EN_REG}                    0x0004
+${SWRST_REG}                 0x0008
+${CTRL_REG}                  0x000C
+${STATUS_REG}                0x0010
+${SYNCSWSET_REG}             0x0014
+${SYNCSWCLR_REG}             0x0018
+${SYNCHWEN_REG}              0x001C
+${SYNCHWSEL_REG}             0x0020
+${SYNCSTATUS_REG}            0x0024
+${CHEN_REG}                  0x0028
+${CHDIS_REG}                 0x002C
+${CHSTATUS_REG}              0x0030
+${CHBUSY_REG}                0x0034
+${CHDONE_REG}                0x0038
+${DBGHALT_REG}               0x003C
+${SWREQ_REG}                 0x0040
+${REQDIS_REG}                0x0044
+${REQPEND_REG}               0x0048
+${LINKLOAD_REG}              0x004C
+${REQCLEAR_REG}              0x0050
+${IF_REG}                    0x0054
+${IEN_REG}                   0x0058
+${REQABORT_REG}              0x005C
+${ABORTSTATUS_REG}           0x0060
+${CH0_CTRL_REG}              0x0078
+${CH1_CTRL_REG}              0x00A8
+${CH0_LINK_REG}              0x0084
+${CH1_LINK_REG}              0x00B4
+#ldma test vars
+${LDMA_CTRL}                 0x1000000
+${EXPECTED_START_CHDONE}     0x0
+${EXPECTED_END_CHDONE}       0x1
+${EXPECTED_END_CHDONE_ALL}   0x3
+${CHANNEL0}                  0 
+${CHANNEL1}                  1 
+${BLOCKSIZE_0}               0
+${BLOCKSIZE_1}               1
+${GENERIC_CH_CTRL}           0x50310000  
+${CH_CTRL_0_FOR_LINK_TEST}   0xD0310000
+${CH_LINK_0_FOR_LINK_TEST}   0x12
+${CH_LINK_1_FOR_LINK_TEST}   0x51
+
+*** Keywords ***
+Create Machine
+    Execute Command             mach create "test"
+    Execute Command             machine LoadPlatformDescriptionFromString ${REPL_STRING}
+
+Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE
+    [Arguments]                 ${channel}
+    #sets fixed priority to 1 and enables done set as well as req mode all
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CTRL_REG} 0x2000000
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CH${channel}_CTRL_REG} ${GENERIC_CH_CTRL} 
+
+Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE Block
+    [Arguments]                 ${channel}  ${blockSize}
+    #sets fixed priority to 1 and enables done set as well as req mode block and block size 2 and transfer count will be 4
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CTRL_REG} 0x2000000
+    #Sets channel descriptor DSTMODE absolute SRCMODE relative DSTINC 1 SIZE BYTE SRCINC 0  with configurable blocksize as an input argument
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CH${channel}_CTRL_REG} 0x501200${blockSize}0
+
+Set LDMA_DESCRIPTOR_LINKREL_M2M_BYTE_SINGLE_JMP
+    [Arguments]                 ${first_channel}  ${second_channel}
+    #sets fixed priority to 1 and enables done set as well as req mode block and block size 2 and transfer count will be 4
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CTRL_REG} 0x2000000   
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CH${first_channel}_CTRL_REG} ${CH_CTRL_0_FOR_LINK_TEST}
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CH${first_channel}_LINK_REG} ${CH_LINK_0_FOR_LINK_TEST}
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CH${second_channel}_CTRL_REG} ${GENERIC_CH_CTRL} 
+    Execute Command             sysbus.ldma WriteDoubleWordToLdma ${CH${second_channel}_LINK_REG} ${CH_LINK_1_FOR_LINK_TEST}
+
+*** Test Cases ***
+LDMA Initialization
+    Create Machine
+    Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE  ${CHANNEL0}
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CTRL_REG}
+    #enable channel 0
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${CHEN_REG} 0x1
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHEN_REG}
+    Should Be Equal As Integers   ${read_val}  1
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHSTATUS_REG}
+    Should Be Equal As Integers   ${read_val}  1
+
+Single Transfer SW Request
+    Create Machine
+    Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE  ${CHANNEL0}
+    #enable channel 0
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHDONE_REG}
+    Should Be Equal As Integers   ${read_val}  ${EXPECTED_START_CHDONE}
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${CHEN_REG} 0x1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${SWREQ_REG} 0x1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${IEN_REG} 0x1
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHDONE_REG}
+    Should Be Equal As Integers   ${read_val}  ${EXPECTED_END_CHDONE}
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHBUSY_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${irqState}=                  Execute Command  sysbus.ldma Channel0IRQ
+    Should Contain                ${irqState}  GPIO: set
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  1
+
+Burst SW ALL Transfer Request
+    Create Machine
+    Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE  ${CHANNEL0}
+    Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE  ${CHANNEL1}
+    #enable channel 0 and channel 1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${CHEN_REG} 0x3
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${SWREQ_REG} 0x1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${IEN_REG} 0x3
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHDONE_REG}
+    Should Be Equal As Integers   ${read_val}  ${EXPECTED_END_CHDONE_ALL}
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHBUSY_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${irqState}=                  Execute Command  sysbus.ldma Channel0IRQ
+    Should Contain                ${irqState}  GPIO: set
+    ${irqState}=                  Execute Command  sysbus.ldma Channel1IRQ
+    Should Contain                ${irqState}  GPIO: set
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  3
+
+Burst Block SW Transfer Request
+    #Block transer
+    Create Machine
+    Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE Block  ${CHANNEL0}  ${BLOCKSIZE_1}
+    Set LDMA_DESCRIPTOR_SINGLE_M2M_BYTE Block  ${CHANNEL1}  ${BLOCKSIZE_0}
+    #enable channel 0 and channel 1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${CHEN_REG} 0x3
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${SWREQ_REG} 0x1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${IEN_REG} 0x3
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHBUSY_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHDONE_REG}
+    Should Be Equal As Integers   ${read_val}  ${EXPECTED_END_CHDONE_ALL}
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHBUSY_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${irqState}=                  Execute Command  sysbus.ldma Channel0IRQ
+    Should Contain                ${irqState}  GPIO: set
+    ${irqState}=                  Execute Command  sysbus.ldma Channel1IRQ
+    Should Contain                ${irqState}  GPIO: set
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  3
+
+Link Transfer Relative Request
+    Create Machine
+    Set LDMA_DESCRIPTOR_LINKREL_M2M_BYTE_SINGLE_JMP  ${CHANNEL0}  ${CHANNEL1}
+    #enable channel 0 and channel 1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${CHEN_REG} 0x3
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${SWREQ_REG} 0x1
+    Execute Command               sysbus.ldma WriteDoubleWordToLdma ${IEN_REG} 0x3
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHBUSY_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHDONE_REG}
+    Should Be Equal As Integers   ${read_val}  ${EXPECTED_END_CHDONE_ALL}
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${CHBUSY_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${irqState}=                  Execute Command  sysbus.ldma Channel0IRQ
+    Should Contain                ${irqState}  GPIO: set
+    ${irqState}=                  Execute Command  sysbus.ldma Channel1IRQ
+    Should Contain                ${irqState}  GPIO: set
+    ${read_val}=                  Execute Command  sysbus.ldma ReadDoubleWordFromLdma ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  3

--- a/tests/peripherals/SiLabs/SEQACC_1.robot
+++ b/tests/peripherals/SiLabs/SEQACC_1.robot
@@ -1,0 +1,1014 @@
+*** Variables ***
+${PROTIMER_BLOCK_ADDRESS}       0xA021C000
+${SEQACC_BLOCK_ADDRESS}         0xA025C000
+${RAM_ADDRESS}                  0x10000000
+# With a 38.4MHz clock (currently hard-coded in the radio model), setting the integer part of 
+# PRECOUNT to 383 sets the PRECNT overflow to a nice round frequency of 100KHz (one tick very 10us)
+${PROTIMER_PRECOUNT_TOP_VALUE}  0x017F0000
+${SEQ0_START_ADDRESS}           0x10000000
+${SEQ1_START_ADDRESS}           0x10001000
+${BASE_ADDRESS_0}               0x10010000
+${BASE_ADDRESS_1}               0x10020000
+${SPARE_RAM_ADDRESS}            0x10030000
+${END_SEQUENCE}                 0xFFFFFFFF
+@{TEST_WORDS}                   0xABCD1234  0xDEADBEEF  0xBAADFEED
+@{TEST_WORDS_2}                 0x99887766  0x55443322  0x1100FFEE
+@{ZEROED_WORDS}                 0  0  0
+${REPL_STRING}=                 SEPARATOR=
+...  """                                                                                                                      ${\n}
+...  radio: Wireless.SiLabs_xG301_LPW @ {                                                                                     ${\n}
+...  ${SPACE*4}sysbus new Bus.BusMultiRegistration { address: ${PROTIMER_BLOCK_ADDRESS}; size: 0x4000; region: "protimer_s" } ${\n}
+...  }                                                                                                                        ${\n}
+...  ram: Memory.MappedMemory @ sysbus ${RAM_ADDRESS}                                                                         ${\n}
+...  ${SPACE*4}size: 0x400000                                                                                                 ${\n}
+...  seqacc: Miscellaneous.SiLabs.SiLabs_SEQACC_1 @ sysbus ${SEQACC_BLOCK_ADDRESS}                                            ${\n}
+...  ${SPACE*4}frequency: 38400000                                                                                            ${\n}
+...  ${SPACE*4}protocolTimer: radio                                                                                           ${\n}
+...  """
+
+# PROTIMER registers
+${PROTIMER_CTRL_REG}            0x0008
+${PROTIMER_CMD_REG}             0x000C
+${PROTIMER_BASECNT_REG}         0x001C
+${PROTIMER_WRAPCNT_REG}         0x0020
+${PROTIMER_PRECNT_TOP_REG}      0x0034
+${PROTIMER_BASECNT_TOP_REG}     0x0038
+${PROTIMER_WRAPCNT_TOP_REG}     0x003C
+
+# SEQACC registers
+${SEQACC_ENABLE_REG}            0x0004
+${SEQACC_CONFIG_REG}            0x0010
+${SEQACC_CTRL_REG}              0x0014
+${SEQACC_STATUS_REG}            0x0018
+${SEQACC_BUSY_REG}              0x001C
+${SEQACC_IF_REG}                0x0020
+${SEQACC_IEN_REG}               0x0024
+${SEQACC_CTRL2_REG}             0x0030
+${SEQACC_EQ_COND_MASK_0_REG}    0x003C
+${SEQACC_EQ_COND_MASK_1_REG}    0x0040
+${SEQACC_START_ADDRESS_0_REG}   0x0050
+${SEQACC_SEQUENCE_CFG_0_REG}    0x0054
+${SEQACC_START_ADDRESS_1_REG}   0x0058
+${SEQACC_SEQUENCE_CFG_1_REG}    0x005C
+${SEQACC_BASE_ADDRESS_0_REG}    0x00D0
+${SEQACC_BASE_ADDRESS_1_REG}    0x00D4
+
+*** Keywords ***
+Create Machine
+    Execute Command             mach create "test"
+    Execute Command             machine LoadPlatformDescriptionFromString ${REPL_STRING}
+    Execute Command             logLevel 3
+
+Read ProTimer Register
+    [Arguments]  ${offset}
+    ${addr}                     evaluate  ${PROTIMER_BLOCK_ADDRESS} + ${offset}
+    ${reg_val}=                 Execute Command  sysbus ReadDoubleWord ${addr}
+    RETURN                      ${reg_val}
+
+Write ProTimer Register
+    [Arguments]  ${offset}  ${value}
+    ${addr}                     evaluate  ${PROTIMER_BLOCK_ADDRESS} + ${offset}
+    Execute Command             sysbus WriteDoubleWord ${addr} ${value}
+
+Read SeqAcc Register
+    [Arguments]  ${offset}
+    ${addr}                     evaluate  ${SEQACC_BLOCK_ADDRESS} + ${offset}
+    ${reg_val}=                 Execute Command  sysbus ReadDoubleWord ${addr}
+    RETURN                      ${reg_val}
+
+Write SeqAcc Register
+    [Arguments]  ${offset}  ${value}
+    ${addr}                     evaluate  ${SEQACC_BLOCK_ADDRESS} + ${offset}
+    Execute Command             sysbus WriteDoubleWord ${addr} ${value}
+
+Configure And Start Protimer
+    # Set the PRECNT to be sourced by the clock, BASECNT and WRAPCNT sourced by PRECNT overflows
+    Write ProTimer Register     ${PROTIMER_CTRL_REG}  0x540
+    Write ProTimer Register     ${PROTIMER_PRECNT_TOP_REG}  ${PROTIMER_PRECOUNT_TOP_VALUE}
+    Write ProTimer Register     ${PROTIMER_BASECNT_TOP_REG}  0xFFFFFFFF
+    Write ProTimer Register     ${PROTIMER_WRAPCNT_TOP_REG}  0xFFFFFFFF
+    # Start the protimer
+    Write ProTimer Register     ${PROTIMER_CMD_REG}  0x1
+
+Configure Sequencer Accelerator
+    # Enable the Sequencer Accelerator
+    Write SeqAcc Register       ${SEQACC_ENABLE_REG}  0x1
+    # BASEPOS=24, TIMEBASE=PreCountOverflow
+    Write SeqAcc Register       ${SEQACC_CONFIG_REG}  0x10180
+    # CONT_WRITE_POS=16
+    Write SeqAcc Register       ${SEQACC_SEQUENCE_CFG_0_REG}  0x10
+    Write SeqAcc Register       ${SEQACC_SEQUENCE_CFG_1_REG}  0x10
+    # Start Addresses
+    Write SeqAcc Register       ${SEQACC_START_ADDRESS_0_REG}  ${SEQ0_START_ADDRESS}
+    Write SeqAcc Register       ${SEQACC_START_ADDRESS_1_REG}  ${SEQ1_START_ADDRESS}
+    # Base Addresses
+    Write SeqAcc Register       ${SEQACC_BASE_ADDRESS_0_REG}  ${BASE_ADDRESS_0}
+    Write SeqAcc Register       ${SEQACC_BASE_ADDRESS_1_REG}  ${BASE_ADDRESS_1}
+    # Enable interrupts
+    Write SeqAcc Register       ${SEQACC_IEN_REG}  0xE00000FF
+       
+Assert SeqAcc IRQ Is Set
+    ${irqState}=                    Execute Command  sysbus.seqacc HostIRQ
+    Should Contain                  ${irqState}  GPIO: set
+
+Assert SeqAcc IRQ Is Unset
+    ${irqState}=                    Execute Command  sysbus.seqacc HostIRQ
+    Should Contain                  ${irqState}  GPIO: unset
+
+Clear SeqAcc Interrupt              
+    Write SeqAcc Register           ${SEQACC_IF_REG}  0
+
+Set Instruction With ExtOpCode
+    [Arguments]  ${index}  ${offset}  ${arg_word}  ${data_word}  ${append_end_sequence}
+    IF  ${index} == 0
+        ${start_addr}=              Set Variable  ${SEQ0_START_ADDRESS}
+    ELSE
+        ${start_addr}=              Set Variable  ${SEQ1_START_ADDRESS}  
+    END
+    ${arg_addr}                     evaluate  ${start_addr} + ${offset}
+    Execute Command                 sysbus WriteDoubleWord ${arg_addr} ${arg_word}
+    ${move_swap}=                   Get Move Swap Flag  ${index}
+    IF  ${move_swap}
+        ${base_index}               evaluate  (${arg_word} >> 24) & 0xF
+        IF  ${base_index} == 0
+            ${addr}=                Set Variable  ${BASE_ADDRESS_0}
+        ELSE
+            ${addr}=                Set Variable  ${BASE_ADDRESS_1}
+        END
+    ELSE
+        ${addr}                     evaluate  ${arg_addr} + 4
+    END
+    Execute Command                 sysbus WriteDoubleWord ${addr} ${data_word}
+    IF  ${append_end_sequence}
+        ${addr}                     evaluate  ${arg_addr} + 8
+        Execute Command             sysbus WriteDoubleWord ${addr} ${END_SEQUENCE}
+    END
+
+Set Instruction With Length
+    [Arguments]  ${index}  ${offset}  ${arg_word}  ${append_end_sequence}
+    IF  ${index} == 0
+        ${start_addr}=              Set Variable  ${SEQ0_START_ADDRESS}
+    ELSE
+        ${start_addr}=              Set Variable  ${SEQ1_START_ADDRESS}  
+    END
+    ${length}                       evaluate  (${arg_word} >> 16) & 0xFF
+    ${arg_addr}                     evaluate  ${start_addr} + ${offset}
+    Execute Command                 sysbus WriteDoubleWord ${arg_addr} ${arg_word}
+    ${move_swap}=                   Get Move Swap Flag  ${index}
+    IF  ${move_swap}
+        ${base_index}               evaluate  (${arg_word} >> 24) & 0xF
+        IF  ${base_index} == 0
+            ${addr}=                Set Variable  ${BASE_ADDRESS_0}
+        ELSE
+            ${addr}=                Set Variable  ${BASE_ADDRESS_1}
+        END
+    ELSE
+        ${addr}                     evaluate  ${arg_addr} + 4
+    END    
+    FOR  ${i}  IN RANGE  0  ${length}
+        Execute Command             sysbus WriteDoubleWord ${addr} ${TEST_WORDS}[${i}]
+        ${addr}                     evaluate  ${addr} + 4
+    END
+    IF  ${append_end_sequence}
+        ${addr}                     evaluate  ${arg_addr} + 4 + ${length}*4
+        Execute Command             sysbus WriteDoubleWord ${addr} ${END_SEQUENCE}
+    END
+
+Start Sequence
+    [Arguments]  ${index}
+    IF  ${index} == 0
+        ${reg_val}=                 Set Variable  0x1
+    ELSE
+        ${reg_val}=                 Set Variable  0x2
+    END
+    Write SeqAcc Register           ${SEQACC_CTRL_REG}  ${reg_val}
+
+Abort Sequence
+    [Arguments]  ${index}
+    IF  ${index} == 0
+        ${reg_val}=                 Set Variable  0x10000
+    ELSE
+        ${reg_val}=                 Set Variable  0x20000
+    END
+    Write SeqAcc Register           ${SEQACC_CTRL_REG}  ${reg_val}
+
+Set Move Swap Flag
+    [Arguments]  ${index}  ${flag}
+    IF  ${index} == 0
+        ${reg_val}=                 Read SeqAcc Register  ${SEQACC_SEQUENCE_CFG_0_REG}
+    ELSE
+        ${reg_val}=                 Read SeqAcc Register  ${SEQACC_SEQUENCE_CFG_1_REG}
+    END
+    IF  ${flag}
+        ${reg_val}                  evaluate  (${reg_val} | (1 << 14))
+    ELSE
+        ${reg_val}                  evaluate  (${reg_val} & ~(1 << 14))
+    END
+    IF  ${index} == 0
+        Write SeqAcc Register       ${SEQACC_SEQUENCE_CFG_0_REG}  ${reg_val}
+    ELSE
+        Write SeqAcc Register       ${SEQACC_SEQUENCE_CFG_1_REG}  ${reg_val}
+    END
+
+Get Move Swap Flag
+    [Arguments]  ${index}
+    IF  ${index} == 0
+        ${reg_val}=                 Read SeqAcc Register  ${SEQACC_SEQUENCE_CFG_0_REG}
+    ELSE
+        ${reg_val}=                 Read SeqAcc Register  ${SEQACC_SEQUENCE_CFG_1_REG}
+    END
+    ${ret}                          evaluate  ((${reg_val} & (1 << 14)) > 0) 
+    RETURN                          ${ret}
+
+Set Disable Reset Absolute Delay Counter
+    [Arguments]  ${index}  ${flag}
+    IF  ${index} == 0
+        ${reg_val}=                 Read SeqAcc Register  ${SEQACC_SEQUENCE_CFG_0_REG}
+    ELSE
+        ${reg_val}=                 Read SeqAcc Register  ${SEQACC_SEQUENCE_CFG_1_REG}
+    END
+    IF  ${flag}
+        ${reg_val}                  evaluate  (${reg_val} | (1 << 13))
+    ELSE
+        ${reg_val}                  evaluate  (${reg_val} & ~(1 << 13))
+    END
+    IF  ${index} == 0
+        Write SeqAcc Register       ${SEQACC_SEQUENCE_CFG_0_REG}  ${reg_val}
+    ELSE
+        Write SeqAcc Register       ${SEQACC_SEQUENCE_CFG_1_REG}  ${reg_val}
+    END
+
+Reset Absolute Delay Counter
+    Write SeqAcc Register           ${SEQACC_CTRL2_REG}  0x1
+
+Clear Memory
+    [Arguments]  ${clear_addr}  ${length}
+    FOR  ${i}  IN RANGE  0  ${length}
+        ${addr}                     evaluate  ${clear_addr} + ${i}*4
+        Execute Command             sysbus WriteDoubleWord ${addr} 0
+    END
+
+Check Memory Content
+    [Arguments]  ${check_addr}  ${list}  ${list_start_index}  ${length}
+    FOR  ${i}  IN RANGE  0  ${length}
+        ${addr}                       evaluate  ${check_addr} + ${i}*4
+        ${read_val}=                  Execute Command  sysbus ReadDoubleWord ${addr}
+        ${index}                      evaluate  ${list_start_index} + ${i}
+        Should Be Equal As Integers   ${read_val}  ${list}[${index}]
+    END
+
+*** Test Cases ***
+
+Write Op Codes
+    Create Machine
+    Configure Sequencer Accelerator
+    Assert SeqAcc IRQ Is Unset
+
+    # OpCode: Write at baseAddress0, length=1
+    Clear Memory                      ${BASE_ADDRESS_0}  1
+    Set Instruction With Length       0  0  0x00010000  True
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    Assert SeqAcc IRQ Is Unset
+
+    # OpCode: Write at baseAddress1, length=1
+    Clear Memory                      ${BASE_ADDRESS_1}  1
+    Set Instruction With Length       0  0  0x01010000  True
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_1}  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    Assert SeqAcc IRQ Is Unset
+
+    # OpCode: Write at baseAddress0, length=3
+    Clear Memory                      ${BASE_ADDRESS_0}  3
+    Set Instruction With Length       0  0  0x00030000  True
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  0  3
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: WriteNoInc at baseAddress0, length=3
+    Clear Memory                      ${BASE_ADDRESS_0}  3
+    Set Instruction With Length       0  0  0x90030000  True
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  2  1
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  2
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+Move Op Codes
+    Create Machine
+    Configure Sequencer Accelerator
+
+    # OpCode: Move at baseAddress0, length=1
+    Clear Memory                      ${BASE_ADDRESS_0}  1
+    Set Instruction With Length       0  0  0x50010000  True
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: Move at baseAddress0, length=3
+    Clear Memory                      ${BASE_ADDRESS_0}  3
+    Set Instruction With Length       0  0  0x50030000  True
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  0  3
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: MoveNoInc at baseAddress0, length=3
+    Clear Memory                      ${BASE_ADDRESS_0}  3
+    Set Instruction With Length       0  0  0x60030000  True
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  2  1
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  2
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: MoveBlock at baseAddress0, length=3
+    Clear Memory                      ${BASE_ADDRESS_0}  3
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${SPARE_RAM_ADDRESS} + ${i}*4
+        Execute Command               sysbus WriteDoubleWord ${addr} ${TEST_WORDS}[${i}]
+    END
+    Execute Command                   sysbus WriteDoubleWord ${SEQ0_START_ADDRESS} 0xC0030000
+    ${addr}                           evaluate  ${SEQ0_START_ADDRESS} + 4
+    Execute Command                   sysbus WriteDoubleWord ${addr} ${SPARE_RAM_ADDRESS}
+    ${addr}                           evaluate  ${addr} + 4
+    Execute Command                   sysbus WriteDoubleWord ${addr} ${END_SEQUENCE}
+    Start Sequence                    0
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  0  3
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: Move at baseAddress0, length=1, with MOVSWAP set
+    Set Move Swap Flag                0  True
+    Clear Memory                      ${SEQ0_START_ADDRESS}+4   1
+    Set Instruction With Length       0  0  0x50010000  True
+    Start Sequence                    0
+    Check Memory Content              ${SEQ0_START_ADDRESS}+4  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: Move at baseAddress0, length=3, with MOVSWAP set
+    Clear Memory                      ${SEQ0_START_ADDRESS}+4   3
+    Set Instruction With Length       0  0  0x50030000  True
+    Start Sequence                    0
+    Check Memory Content              ${SEQ0_START_ADDRESS}+4  ${TEST_WORDS}  0  3
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: MoveBlock at baseAddress0, length=3, , with MOVSWAP set
+    Clear Memory                      ${SPARE_RAM_ADDRESS}  3
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${BASE_ADDRESS_0} + ${i}*4
+        Execute Command               sysbus WriteDoubleWord ${addr} ${TEST_WORDS}[${i}]
+    END
+    Execute Command                   sysbus WriteDoubleWord ${SEQ0_START_ADDRESS} 0xC0030000
+    ${addr}                           evaluate  ${SEQ0_START_ADDRESS} + 4
+    Execute Command                   sysbus WriteDoubleWord ${addr} ${SPARE_RAM_ADDRESS}
+    ${addr}                           evaluate  ${addr} + 4
+    Execute Command                   sysbus WriteDoubleWord ${addr} ${END_SEQUENCE}
+    Start Sequence                    0
+    Check Memory Content              ${SPARE_RAM_ADDRESS}  ${TEST_WORDS}  0  3
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+Logic Operator Op Codes
+    Create Machine
+    Configure Sequencer Accelerator
+
+    # OpCode: And at baseAddress0, length=3
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${BASE_ADDRESS_0} + ${i}*4
+        Execute Command               sysbus WriteDoubleWord ${addr} ${TEST_WORDS_2}[${i}]
+    END
+    Set Instruction With Length       0  0  0x10030000  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${BASE_ADDRESS_0} + ${i}*4
+        ${read_val}=                  Execute Command  sysbus ReadDoubleWord ${addr}
+        ${expected_val}               evaluate  ${TEST_WORDS}[${i}] & ${TEST_WORDS_2}[${i}]
+        Should Be Equal As Integers   ${read_val}  ${expected_val}
+    END
+
+    # OpCode: Xor at baseAddress0, length=3
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${BASE_ADDRESS_0} + ${i}*4
+        Execute Command               sysbus WriteDoubleWord ${addr} ${TEST_WORDS_2}[${i}]
+    END
+    Set Instruction With Length       0  0  0x20030000  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${BASE_ADDRESS_0} + ${i}*4
+        ${read_val}=                  Execute Command  sysbus ReadDoubleWord ${addr}
+        ${expected_val}               evaluate  ${TEST_WORDS}[${i}] ^ ${TEST_WORDS_2}[${i}]
+        Should Be Equal As Integers   ${read_val}  ${expected_val}
+    END
+
+    # OpCode: Or at baseAddress0, length=3
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${BASE_ADDRESS_0} + ${i}*4
+        Execute Command               sysbus WriteDoubleWord ${addr} ${TEST_WORDS_2}[${i}]
+    END
+    Set Instruction With Length       0  0  0x30030000  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    FOR  ${i}  IN RANGE  0  3
+        ${addr}                       evaluate  ${BASE_ADDRESS_0} + ${i}*4
+        ${read_val}=                  Execute Command  sysbus ReadDoubleWord ${addr}
+        ${expected_val}               evaluate  ${TEST_WORDS}[${i}] | ${TEST_WORDS_2}[${i}]
+        Should Be Equal As Integers   ${read_val}  ${expected_val}
+    END
+
+Jump Op Codes
+    Create Machine
+    Configure Sequencer Accelerator
+
+    # OpCode: Jump, absolute address, dataword=0 (if data word is 0, the jump instruction is ignored)
+    Clear Memory                      ${BASE_ADDRESS_0}  1
+    Set Instruction With ExtOpCode    0  0  0xA0010000  0x0  False
+    # Write, length 1
+    Set Instruction With Length       0  8  0x00010000  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  0  1
+
+    # OpCode: Jump, relative address, dataword=0 (if data word is 0, the jump instruction is ignored)
+    Clear Memory                      ${BASE_ADDRESS_0}  1
+    Set Instruction With ExtOpCode    0  0  0xA0000000  0x0  False
+    # Write, length 1
+    Set Instruction With Length       0  8  0x00010000  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    Check Memory Content              ${BASE_ADDRESS_0}  ${TEST_WORDS}  0  1
+
+    # OpCode: Jump, absolute address (should skip write instruction)
+    Clear Memory                      ${BASE_ADDRESS_0}  1
+    ${addr}                           evaluate  ${SEQ0_START_ADDRESS} + 16
+    Set Instruction With ExtOpCode    0  0  0xA0010000  ${addr}  False
+    # Write, length 1
+    Set Instruction With Length       0  8  0x00010000  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    Check Memory Content              ${BASE_ADDRESS_0}  ${ZEROED_WORDS}  0  1
+
+    # OpCode: Jump, relative address (should skip write instruction)
+    Clear Memory                      ${BASE_ADDRESS_0}  1
+    Set Instruction With ExtOpCode    0  0  0xA0000000  8  False
+    # Write, length 1
+    Set Instruction With Length       0  8  0x00010000  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    Check Memory Content              ${BASE_ADDRESS_0}  ${ZEROED_WORDS}  0  1
+
+Delay Op Codes
+    Create Machine
+    Configure Sequencer Accelerator
+    Configure And Start Protimer
+
+    # First make sure protimer is functioning, 1 second of simulation = 100000 PRECNT overflows
+    Execute Command                   emulation RunFor "1"
+    ${read_val}=                      Read ProTimer Register  ${PROTIMER_BASECNT_REG}
+    Should Be Equal As Integers       ${read_val}  100000
+
+    # OpCode: Delay (relative)
+    Set Instruction With ExtOpCode    0  0  0x40000000  99999  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    # Test BUSY register
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_BUSY_REG}
+    Should Be Equal As Integers       ${read_val}  0x1
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: Delay (absolute), DISABSRST = 0, absolute delay counter is reset when sequence start. 
+    Set Instruction With ExtOpCode    0  0  0x40010000  99999  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: Delay (absolute), DISABSRST = 0, absolute delay counter is reset when sequence start. 
+    # Run it one more time to confirm the absolute delay counter gets reset
+    Set Instruction With ExtOpCode    0  0  0x40010000  99999  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    Set Disable Reset Absolute Delay Counter  0  True
+
+    # OpCode: Delay (absolute), DISABSRST = 1, absolute delay counter is NOT reset when sequence start. 
+    # The counter should start from the 100000 value
+    Set Instruction With ExtOpCode    0  0  0x40010000  199999  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    Set Disable Reset Absolute Delay Counter  0  False
+
+    # OpCode: Delay (absolute), DISABSRST = 0, absolute delay counter is reset when sequence start. 
+    # In the middle of the delay, manually reset the absolute delay counter.
+    Set Instruction With ExtOpCode    0  0  0x40010000  99999  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Reset Absolute Delay Counter
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # Test multiple sequences (pending/resuming)
+    # OpCode: Delay (relative)
+    Set Instruction With ExtOpCode    0  0  0x40000000  99999  True
+    Start Sequence                    0
+    # OpCode: Delay (relative)
+    Set Instruction With ExtOpCode    1  0  0x40000000  99999  True
+    Start Sequence                    1
+    # Check sequence 0 is running
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_BUSY_REG}
+    Should Be Equal As Integers       ${read_val}  0x1
+    # Check sequence 1 is pending
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_STATUS_REG}
+    Should Be Equal As Integers       ${read_val}  0x2
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    # Check sequence 1 is running
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_BUSY_REG}
+    Should Be Equal As Integers       ${read_val}  0x2
+    # Check no sequence is pending
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_STATUS_REG}
+    Should Be Equal As Integers       ${read_val}  0x0
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    # Check no sequence is running
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_BUSY_REG}
+    Should Be Equal As Integers       ${read_val}  0x0
+    # Check no sequence is pending
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_STATUS_REG}
+
+    # Test sequence abort
+    # OpCode: Delay (relative)
+    Set Instruction With ExtOpCode    0  0  0x40000000  99999  True
+    Start Sequence                    0
+    # Check sequence 0 is running
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_BUSY_REG}
+    Should Be Equal As Integers       ${read_val}  0x1
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   emulation RunFor "0.5"
+    Assert SeqAcc IRQ Is Unset
+    Abort Sequence                    0
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    # Check no sequence is running
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_BUSY_REG}
+    Should Be Equal As Integers       ${read_val}  0x0
+    # Check no sequence is pending
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_STATUS_REG}
+
+WaitForRegister Op Codes
+    Create Machine
+    Configure Sequencer Accelerator
+    ${reg_addr}                       Set Variable  ${BASE_ADDRESS_0}
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_1_REG}  0
+    
+    # OpCode: WaitForReg, All
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0
+    Set Instruction With ExtOpCode    0  0  0x70000000  0xFF00FF00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Set only some the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0000FF00
+    Execute Command                   emulation RunFor "0.000005"
+    # Set ALL the bits of the mask bits
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF00FF00
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+    ${read_val}=                      Read SeqAcc Register  ${SEQACC_BUSY_REG}
+    Should Be Equal As Integers       ${read_val}  0
+
+    # OpCode: WaitForReg, Any
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0
+    Set Instruction With ExtOpCode    0  0  0x70010000  0xFF00FF00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Set only some the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0000FF00
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: WaitForReg, NegAll
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF00FF00
+    Set Instruction With ExtOpCode    0  0  0x70020000  0xFF00FF00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Negate only some the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF000000
+    Execute Command                   emulation RunFor "0.000005"
+    # Negate ALL the bits of the mask bits
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x00000000
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: WaitForReg, NegAny
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF00FF00
+    Set Instruction With ExtOpCode    0  0  0x70030000  0xFF00FF00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Negate only some the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF000000
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: WaitForReg, Eq0
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0xFF00FF00
+    Set Instruction With ExtOpCode    0  0  0x70040000  0x0F000F00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Set only some the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Execute Command                   emulation RunFor "0.000005"
+    # Set ALL the bits of the mask bits
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: WaitForReg, Neq0
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0xFF00FF00    
+    Set Instruction With ExtOpCode    0  0  0x70050000  0x0F000F00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Set only some the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0
+
+    # OpCode: WaitForReg, Eq1
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_1_REG}  0xFF00FF00    
+    Set Instruction With ExtOpCode    0  0  0x70060000  0x0F000F00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Set only some the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Execute Command                   emulation RunFor "0.000005"
+    # Set ALL the bits of the mask bits
+    Assert SeqAcc IRQ Is Unset
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: WaitForReg, Neq1
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_1_REG}  0xFF00FF00    
+    Set Instruction With ExtOpCode    0  0  0x70070000  0x0F000F00  True
+    Start Sequence                    0
+    Assert SeqAcc IRQ Is Unset
+    # Set only some the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Execute Command                   emulation RunFor "0.000005"
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+# RENODE-???: Signals haven't been implemented/connected, so we can't test WaitForSig and Trigger Op Codes
+#WaitForSig Op Codes
+#Trigger Op Codes
+
+
+SkipCond Op Codes
+    # RENODE-???: Signals haven't been connected yet, so we can't test signal related skip conditions
+    Create Machine
+    Configure Sequencer Accelerator
+    ${reg_addr}                       Set Variable  ${BASE_ADDRESS_0}
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_1_REG}  0
+
+    # OpCode: SkipCond, RegAll (condition=FALSE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set ONLY SOME of the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0000FF00
+    Set Instruction With ExtOpCode    0  0  0xD0000000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegAll (condition=TRUE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set ALL the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF00FF00
+    Set Instruction With ExtOpCode    0  0  0xD0000000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegAny (condition=FALSE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set NONE of the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x00000000
+    Set Instruction With ExtOpCode    0  0  0xD0010000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegAny (condition=TRUE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set SOME of the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x10000000
+    Set Instruction With ExtOpCode    0  0  0xD0010000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNegAll (condition=FALSE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Negate SOME the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF000000
+    Set Instruction With ExtOpCode    0  0  0xD0020000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNegAll (condition=TRUE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Negate ALL the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x00000000
+    Set Instruction With ExtOpCode    0  0  0xD0020000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNegAny (condition=FALSE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Negate NONE of the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF00FF00
+    Set Instruction With ExtOpCode    0  0  0xD0030000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNegAny (condition=TRUE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Negate SOME of the bits of the mask bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0xFF000000
+    Set Instruction With ExtOpCode    0  0  0xD0030000  0xFF00FF00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegEq0 (condition=FALSE)
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0xFF00FF00
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set SOME of the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Set Instruction With ExtOpCode    0  0  0xD0040000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegEq0 (condition=TRUE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set ALL the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Set Instruction With ExtOpCode    0  0  0xD0040000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNeq0 (condition=FALSE)
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0xFF00FF00
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set ALL the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Set Instruction With ExtOpCode    0  0  0xD0050000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNeq0 (condition=TRUE)
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0xFF00FF00
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set SOME of the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Set Instruction With ExtOpCode    0  0  0xD0050000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegEq1 (condition=FALSE)
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_1_REG}  0xFF00FF00
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set SOME of the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Set Instruction With ExtOpCode    0  0  0xD0060000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegEq1 (condition=TRUE)
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set ALL the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Set Instruction With ExtOpCode    0  0  0xD0060000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNeq1 (condition=FALSE)
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0xFF00FF00
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set ALL the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000F00
+    Set Instruction With ExtOpCode    0  0  0xD0070000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check both writes occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${TEST_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt
+
+    # OpCode: SkipCond, RegNeq1 (condition=TRUE)
+    Write SeqAcc Register             ${SEQACC_EQ_COND_MASK_0_REG}  0xFF00FF00
+    Clear Memory                      ${BASE_ADDRESS_0}+4  1
+    Clear Memory                      ${BASE_ADDRESS_0}+8  1
+    # Set SOME of the bits of the data bits
+    Execute Command                   sysbus WriteDoubleWord ${reg_addr} 0x0F000000
+    Set Instruction With ExtOpCode    0  0  0xD0070000  0x0F000F00  False    
+    # Write at baseAddress0, length=1
+    Set Instruction With Length       0  8  0x00010004  False
+    # Write at baseAddress0+4, length=1
+    Set Instruction With Length       0  16  0x00010008  True
+    Start Sequence                    0
+    # Check only the second write occurred
+    Check Memory Content              ${BASE_ADDRESS_0}+4  ${ZEROED_WORDS}  0  1
+    Check Memory Content              ${BASE_ADDRESS_0}+8  ${TEST_WORDS}  0  1
+    Assert SeqAcc IRQ Is Set
+    Clear SeqAcc Interrupt

--- a/tests/peripherals/SiLabs/SMU_1.robot
+++ b/tests/peripherals/SiLabs/SMU_1.robot
@@ -1,0 +1,47 @@
+*** Comments ***
+The sources used to generate the elf files can be found in the repo
+https://stash.silabs.com/projects/IOT_DSA/repos/renode-logan-preliminary/browse
+
+*** Variables ***
+${REPL_STRING}=  SEPARATOR=\n
+...  """
+...  using "platforms/boards/silabs/brd4402a.repl"
+...
+...  cpu:
+...  ${SPACE*4}enableTrustZone: true
+...  ${SPACE*4}IDAUEnabled: true
+...
+...  smu:
+...  ${SPACE*4}cpu0: cpu
+...  """
+${UART}                             sysbus.usart0
+
+*** Keywords ***
+Create Machine
+    Execute Command                 mach create "test"
+    Execute Command                 machine LoadPlatformDescriptionFromString ${REPL_STRING}
+    Execute Command                 sysbus LoadELF @https://artifactory.silabs.net/artifactory/renode-production/prebuilt/unit-test/efr32xg2_smu_nonsecure.elf
+    Execute Command                 sysbus LoadELF @https://artifactory.silabs.net/artifactory/renode-production/prebuilt/unit-test/efr32xg2_smu_secure.elf
+    Execute Command                 sysbus.cpu VectorTableOffset 0x00000000
+    Execute Command                 emulation SetGlobalSerialExecution true
+
+*** Test Cases ***
+Exercise IDAU
+    Create Machine
+    Execute Command                 cpu AddHookAtWfiStateChange 'self.Log(LogLevel.Warning, "WFI ENTER" if isInWfi else "WFI EXIT" )'
+    Create Log Tester               5
+    Create Terminal Tester          ${UART}
+    Start Emulation
+    Wait For Line On Uart           SMU test
+    Wait For Line On Uart           Configuring SAU
+    Wait For Line On Uart           Configuring ESAU regions in SMU
+    Wait For Line On Uart           Use TT instruction to verify SAU/IDAU programming for various regions
+    Wait For Line On Uart           secure code: addr=0x91b reg(mpu:-1 sau:-1 idau::0) r=1 w=1 nsr=0 nsrw=0 sec=1
+    Wait For Line On Uart           secure data: addr=0x20000000 reg(mpu:-1 sau:-1 idau::4) r=1 w=1 nsr=0 nsrw=0 sec=1
+    Wait For Line On Uart           secure NSC: addr=0x3f000 reg(mpu:-1 sau:0 idau::1) r=1 w=1 nsr=0 nsrw=0 sec=1
+    Wait For Line On Uart           nonsecure data: addr=0x20004800 reg(mpu:-1 sau:2 idau::6) r=1 w=1 nsr=0 nsrw=0 sec=0
+    Wait For Line On Uart           nonsecure vtor: addr=0x20007f00 reg(mpu:-1 sau:2 idau::6) r=1 w=1 nsr=0 nsrw=0 sec=0
+    Wait For Line On Uart           nonsecure code: addr=0x40000 reg(mpu:-1 sau:1 idau::2) r=1 w=1 nsr=0 nsrw=0 sec=0
+    Wait For Line On Uart           Greetings from nonsecure code
+    Wait For Line On Uart           End of test
+

--- a/tests/peripherals/SiLabs/SYSRTC_2.robot
+++ b/tests/peripherals/SiLabs/SYSRTC_2.robot
@@ -1,0 +1,471 @@
+*** Variables ***
+${FREQUENCY}                    25000
+${REPL_STRING}=                 SEPARATOR=
+...  """                                                                  ${\n}
+...  sysrtc: Timers.SiLabs_SYSRTC_2 @ sysbus <0x0, +0x4000>               ${\n}
+...  ${SPACE*4}frequency: ${FREQUENCY}                                    ${\n}
+...  hfxo: Miscellaneous.SiLabs.SiLabs_HFXO_5 @ sysbus <0x4000, +0x4000>  ${\n}
+...  """
+# Registers
+${CMD_REG}                      0x0010
+${STATUS_REG}                   0x0014
+${CNT_REG}                      0x0018
+${MS_CNT_REG}                   0x0024
+${MS_CMP_REG}                   0x0028
+${IF_REG}                       0x0030
+${IEN_REG}                      0x0034
+${GRP0_IF_REG}                  0x0050
+${GRP0_IEN_REG}                 0x0054
+${GRP0_CTRL_REG}                0x0058
+${GRP0_CMP0_REG}                0x005C
+${GRP0_CMP1_REG}                0x0060
+${GRP0_PRETRIG_REG}             0x006C
+${GRP1_IF_REG}                  0x0080
+${GRP1_IEN_REG}                 0x0084
+${GRP1_CTRL_REG}                0x0088
+${GRP1_CMP0_REG}                0x008C
+${GRP1_CMP1_REG}                0x0090
+${GRP1_PRETRIG_REG}             0x009C
+
+*** Keywords ***
+Create Machine
+    Execute Command             mach create "test"
+    Execute Command             machine LoadPlatformDescriptionFromString ${REPL_STRING}
+
+Start Command
+    Execute Command             sysbus.sysrtc WriteDoubleWord ${CMD_REG} 0x1
+
+Stop Command
+    Execute Command             sysbus.sysrtc WriteDoubleWord ${CMD_REG} 0x2
+
+Ms Start Command
+    Execute Command             sysbus.sysrtc WriteDoubleWord ${CMD_REG} 0x4
+
+Ms Stop Command
+    Execute Command             sysbus.sysrtc WriteDoubleWord ${CMD_REG} 0x8
+
+Assert App IRQ Is Set
+    ${irqState}=                    Execute Command  sysbus.sysrtc AppIRQ
+    Should Contain                  ${irqState}  GPIO: set
+
+Assert App IRQ Is Unset
+    ${irqState}=                    Execute Command  sysbus.sysrtc AppIRQ
+    Should Contain                  ${irqState}  GPIO: unset
+
+Assert App Alternate IRQ Is Set
+    ${irqState}=                    Execute Command  sysbus.sysrtc AppAlternateIRQ
+    Should Contain                  ${irqState}  GPIO: set
+
+Assert App Alternate IRQ Is Unset
+    ${irqState}=                    Execute Command  sysbus.sysrtc AppAlternateIRQ
+    Should Contain                  ${irqState}  GPIO: unset
+
+Assert MS IRQ Is Set
+    ${irqState}=                    Execute Command  sysbus.sysrtc MsIRQ
+    Should Contain                  ${irqState}  GPIO: set
+
+Assert MS IRQ Is Unset
+    ${irqState}=                    Execute Command  sysbus.sysrtc MsIRQ
+    Should Contain                  ${irqState}  GPIO: unset
+
+*** Test Cases ***
+Counter/MS Counter
+    Create Machine
+    # Start the Counter
+    Start Command
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    #Start the MS Counter
+    Ms Start Command
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers   ${read_val}  0x9
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  1000
+    # Restart the Counter to verify that MS Counter is not reset
+    Start Command
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  1000
+    # Stop MS counter
+    Ms Stop Command
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    # Start MS counter again to check that it started back from 0
+    Ms Start Command
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${STATUS_REG}
+    Should Be Equal As Integers   ${read_val}  0x9
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  1000
+
+Group0/1 Compare
+    Create Machine
+    # Start the Counter
+    Start Command
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Configure compare values for both group0 and group1 and enable them
+    ${set_val}                    evaluate  ${FREQUENCY} * 2.5
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_CMP0_REG} ${set_val}
+    ${set_val}                    evaluate  ${FREQUENCY} * 3.5
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_CMP0_REG} ${set_val}
+    ${set_val}                    evaluate  ${FREQUENCY} * 4.5
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_CMP1_REG} ${set_val}
+    ${set_val}                    evaluate  ${FREQUENCY} * 5.5
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_CMP1_REG} ${set_val}
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_CTRL_REG} 0x3
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_IEN_REG} 0xF
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_CTRL_REG} 0x3
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IEN_REG} 0xFF
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 3
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x2
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0
+    Assert App IRQ Is Set
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_IF_REG} 0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 4
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x22
+    Assert App IRQ Is Set
+    Assert App Alternate IRQ Is Set
+    Assert Ms IRQ Is Unset
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IF_REG} 0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 5
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x4
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    Assert App IRQ Is Set
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_IF_REG} 0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    # Disable App group1 IRQ, check that App Alternate IRQ still gets set.
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IEN_REG} 0xF0
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 6
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x44
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Set
+    Assert Ms IRQ Is Unset
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IF_REG} 0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+
+Group0/1 Overflow
+    Create Machine
+    # Start the Counter
+    Start Command
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Enable group0 and group1 overflow interrupts
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_IEN_REG} 0x1
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IEN_REG} 0x11
+    # Set Counter to be very close to overflow
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${CNT_REG} 0xFFFFFFFE
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} - 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    Assert App IRQ Is Set
+    Assert App Alternate IRQ Is Set
+    Assert Ms IRQ Is Unset
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x11
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_IF_REG} 0
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IF_REG} 0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    # Enable only group1 alternate overflow interrupts
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_IEN_REG} 0x0
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IEN_REG} 0x10
+    # Set Counter to be very close to overflow
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${CNT_REG} 0xFFFFFFFE
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} - 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Set
+    Assert Ms IRQ Is Unset
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x11
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_IF_REG} 0
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_IF_REG} 0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+
+MS Compare
+    Create Machine
+    # Start the Counter
+    Start Command
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Start the MS Counter
+    Ms Start Command
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  1000
+    # Set the MS compare value and enable the related interrupt
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${MS_CMP_REG} 2500
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${IEN_REG} 0x2
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 3
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  2000
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 4
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  3000
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x2
+
+MS Overflow
+    Create Machine
+    # Start the Counter
+    Start Command
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Start the MS Counter
+    Ms Start Command
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  1000
+    # Enable MS overflow interrupt
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${IEN_REG} 0x1
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+    # Set MS Counter base value to be very close to overflow
+    Execute Command               sysbus.sysrtc MsTimerCounter 0xFFFFFFFE
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  0xFFFFFFFE
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 3
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${MS_CNT_REG}
+    Should Be Equal As Integers   ${read_val}  999
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Set
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${IF_REG} 0x0
+    Assert App IRQ Is Unset
+    Assert App Alternate IRQ Is Unset
+    Assert Ms IRQ Is Unset
+
+Group0/1 Pretrigger
+    Create Machine
+    # Start the Counter
+    Start Command
+    Execute Command               emulation RunFor "1"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Configure Compare value
+    ${set_val}                    evaluate  ${FREQUENCY} * 2
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_CMP0_REG} ${set_val}
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_CMP0_REG} ${set_val}
+    # Configure Pretrigger
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_PRETRIG_REG} 0x37
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_PRETRIG_REG} 0xBF
+    # Enable Compare
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP0_CTRL_REG} 0x1
+    Execute Command               sysbus.sysrtc WriteDoubleWord ${GRP1_CTRL_REG} 0x1
+    # Advance the counter
+    Execute Command               emulation RunFor "0.9992"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2 - 20
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Check Compare and Pretrigger
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x37
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0xBF
+    # Advance the counter
+    Execute Command               emulation RunFor "0.00028"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2 - 13
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Check Compare and Pretrigger
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x37
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x1BF
+    # Advance the counter
+    Execute Command               emulation RunFor "0.00016"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2 - 9
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Check Compare and Pretrigger
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x37
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x3BF
+    # Advance the counter
+    Execute Command               emulation RunFor "0.00016"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2 - 5
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Check Compare and Pretrigger
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x137
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x3BF
+    # Advance the counter
+    Execute Command               emulation RunFor "0.00016"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2 - 1
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Check Compare and Pretrigger
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x0
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x337
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x3BF
+    # Advance the counter
+    Execute Command               emulation RunFor "0.00016"
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${CNT_REG}
+    ${check_val}                  evaluate  ${FREQUENCY} * 2 + 3
+    Should Be Equal As Integers   ${read_val}  ${check_val}
+    # Check Compare and Pretrigger
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x2
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x22
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP0_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x337
+    ${read_val}=                  Execute Command  sysbus.sysrtc ReadDoubleWord ${GRP1_PRETRIG_REG}
+    Should Be Equal As Integers   ${read_val}  0x3BF

--- a/tests/peripherals/SiLabs/TIMER_2.robot
+++ b/tests/peripherals/SiLabs/TIMER_2.robot
@@ -1,0 +1,291 @@
+*** Variables ***
+${CLOCK_FREQUENCY}              50000
+# A prescaler value of 1 actually causes the clock frequency to be halved
+${PRESCALER}                    1
+${FREQUENCY}                    25000
+${REPL_STRING}=                 SEPARATOR=
+...  """                                                        ${\n}
+...  timer: Timers.SiLabs_TIMER_2 @ sysbus <0x0, +0x4000>       ${\n}
+...  ${SPACE*4}frequency: ${CLOCK_FREQUENCY}                    ${\n}
+...  """
+# Registers
+${CFG_REG}                      0x0004
+${CTRL_REG}                     0x0008
+${CMD_REG}                      0x000C
+${STATUS_REG}                   0x0010
+${IF_REG}                       0x0018
+${IEN_REG}                      0x001C
+${TOP_REG}                      0x0020
+${CNT_REG}                      0x0028
+${CCO_CFG}                      0x0060
+${CCO_CTRL}                     0x0064
+${CCO_OC}                       0x0070
+${CC1_CFG}                      0x0090
+${CC1_CTRL}                     0x0094
+${CC1_OC}                       0x00A0
+
+*** Keywords ***
+Create Machine
+    Execute Command                 mach create "test"
+    Execute Command                 machine LoadPlatformDescriptionFromString ${REPL_STRING}
+    Execute Command                 logLevel 1 sysbus.timer
+
+Configure Timer
+    [Arguments]  ${down_count}  ${one_shot}
+    ${reg_val}                      Evaluate  ${PRESCALER} << 18
+    IF  ${down_count}
+        ${reg_val}                  Evaluate  ${reg_val} | 0x1
+    END
+    IF  ${one_shot}
+        ${reg_val}                  Evaluate  ${reg_val} | 0x10
+    END
+    Execute Command                 sysbus WriteDoubleWord ${CFG_REG} ${reg_val}
+
+Set Top Value
+    [Arguments]  ${top_val}
+    Execute Command                 sysbus WriteDoubleWord ${TOP_REG} ${top_val}
+
+Start Command
+    Execute Command                 sysbus.timer WriteDoubleWord ${CMD_REG} 0x1
+
+Stop Command
+    Execute Command                 sysbus.timer WriteDoubleWord ${CMD_REG} 0x2
+
+Assert Counter Value
+    [Arguments]  ${expected_val}
+    ${current_val}=                 Execute Command  sysbus.timer ReadDoubleWord ${CNT_REG}
+    Should Be Equal As Integers     ${expected_val}  ${current_val}
+
+Assert Timer Is Running
+    [Arguments]  ${is_running}
+    ${read_val}=                    Execute Command  sysbus.timer ReadDoubleWord ${STATUS_REG}
+    ${read_val}=                    Convert To Integer  ${read_val}
+    ${check_val}                    Evaluate  ${read_val} & 0x1
+    IF  ${is_running}
+        Should Be Equal As Integers  ${check_val}  0x1
+    ELSE
+        Should Be Equal As Integers  ${check_val}  0x0
+    END
+
+Assert IRQ Is Set
+    ${irqState}=                    Execute Command  sysbus.timer IRQ
+    Should Contain                  ${irqState}  GPIO: set
+
+Assert IRQ Is Unset
+    ${irqState}=                    Execute Command  sysbus.timer IRQ
+    Should Contain                  ${irqState}  GPIO: unset
+
+*** Test Cases ***
+Overflow
+    Create Machine
+    Assert IRQ Is Unset
+    Assert Timer Is Running         False
+    # Configure the timer to count up, no one-shot mode
+    Configure Timer                 False  False
+    # Enable all implemented interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IEN_REG} 0x7F3
+    # Set top value so that the counter overflows right at the 2 second mark
+    ${top_val}                      Evaluate  ${FREQUENCY} * 2
+    Set Top Value                   ${top_val}
+    Assert Timer Is Running         False
+    # Start the timer
+    Start Command
+    Assert Timer Is Running         True
+    Assert Counter Value            0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    ${check_val}                    Evaluate  ${FREQUENCY} * 1
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the overflow interrupt fired
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    # Upon overflow, expect the timer to restart from 0
+    Assert Counter Value            0
+    # Go around one more time
+    Execute Command                 emulation RunFor "2"
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    ${check_val}                    Evaluate  ${FREQUENCY} * 1
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    # Stop the timer
+    Stop Command
+    Assert IRQ Is Unset
+    Assert Timer Is Running         False
+    Assert Counter Value            0
+
+Underflow
+    Create Machine
+    Assert IRQ Is Unset
+    Assert Timer Is Running         False
+    # Configure the timer to count down, no one-shot mode
+    Configure Timer                 True  False
+    # Enable all implemented interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IEN_REG} 0x7F3
+    # Set top value so that the counter overflows right at the 2 second mark
+    ${top_val}                      Evaluate  ${FREQUENCY} * 2
+    Set Top Value                   ${top_val}
+    Assert Timer Is Running         False
+    # Start the timer
+    Start Command
+    Assert Timer Is Running         True
+    ${check_val}                    Evaluate  ${FREQUENCY} * 2
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    ${check_val}                    Evaluate  ${FREQUENCY} * 1
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the underflow interrupt fired
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x2
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    # Upon underflow, expect the timer to restart from the top value
+    ${check_val}                    Evaluate  ${FREQUENCY} * 2
+    Assert Counter Value            ${check_val}
+    # Go around one more time
+    Execute Command                 emulation RunFor "2"
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x2
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    ${check_val}                    Evaluate  ${FREQUENCY} * 1
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    # Stop the timer
+    Stop Command
+    Assert IRQ Is Unset
+    Assert Timer Is Running         False
+    Assert Counter Value            0
+
+One Shot Mode
+    Create Machine
+    Assert IRQ Is Unset
+    Assert Timer Is Running         False
+    # Configure the timer to count up, one-shot mode
+    Configure Timer                 False  True
+    # Enable all implemented interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IEN_REG} 0x7F3
+    # Set top value so that the counter overflows right at the 2 second mark
+    ${top_val}                      Evaluate  ${FREQUENCY} * 2
+    Set Top Value                   ${top_val}
+    Assert Timer Is Running         False
+    # Start the timer
+    Start Command
+    Assert Timer Is Running         True
+    Assert Counter Value            0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    ${check_val}                    Evaluate  ${FREQUENCY} * 1
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the overflow interrupt fired
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    # Check that the timer is no longer running
+    Assert Timer Is Running         False
+    Execute Command                 emulation RunFor "2"
+    Assert IRQ Is Unset
+
+Channel Compare
+    Create Machine
+    Assert IRQ Is Unset
+    Assert Timer Is Running         False
+    # Configure the timer to count up, no one-shot mode
+    Configure Timer                 False  False
+    # Enable all implemented interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IEN_REG} 0x7F3
+    # Set top value so that the counter overflows right at the 5 second mark
+    ${top_val}                      Evaluate  ${FREQUENCY} * 5
+    Set Top Value                   ${top_val}
+    Assert Timer Is Running         False
+    # Start the timer
+    Start Command
+    Assert Timer Is Running         True
+    Assert Counter Value            0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    ${check_val}                    Evaluate  ${FREQUENCY} * 1
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    # Set Channel 0 to hit the compare event right at the 3 second mark
+    ${set_val}                      Evaluate  ${FREQUENCY} * 3
+    Execute Command                 sysbus.timer WriteDoubleWord ${CCO_OC} ${set_val}
+    Execute Command                 sysbus.timer WriteDoubleWord ${CCO_CFG} 0x2
+    Execute Command                 emulation RunFor "1"
+    ${check_val}                    Evaluate  ${FREQUENCY} * 2
+    Assert Counter Value            ${check_val}
+    Assert IRQ Is Unset
+    # Set Channel 1 to hit the compare event right at the 4 second mark
+    ${set_val}                      Evaluate  ${FREQUENCY} * 4
+    Execute Command                 sysbus.timer WriteDoubleWord ${CC1_OC} ${set_val}
+    Execute Command                 sysbus.timer WriteDoubleWord ${CC1_CFG} 0x2
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the CC0 interrupt fires
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x10
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the CC1 interrupt fires
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x20
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the overflow interrupt fired
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    # Go around one more time
+    Execute Command                 emulation RunFor "3"
+    # Check that (only) the CC0 interrupt fires
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x10
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the CC1 interrupt fires
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x20
+    # Clear interrupts
+    Execute Command                 sysbus.timer WriteDoubleWord ${IF_REG} 0
+    Assert IRQ Is Unset
+    Execute Command                 emulation RunFor "1"
+    # Check that (only) the overflow interrupt fired
+    Assert IRQ Is Set
+    ${read_val}=                  Execute Command  sysbus.timer ReadDoubleWord ${IF_REG}
+    Should Be Equal As Integers   ${read_val}  0x1
+

--- a/tests/platforms/SiLabs/ble-zigbee-dmp.robot
+++ b/tests/platforms/SiLabs/ble-zigbee-dmp.robot
@@ -1,0 +1,214 @@
+*** Variables ***
+# The ELF variable must be set from command line to the Zigbee+BLE dynamic multi-protocol light ELF file to be used. 
+# Example of SLC generation line for board 4186c (EFR32xG24): 
+# sled slc generate -s $GSDK_PATH -p $GSDK_PATH/protocol/zigbee/app/projects/multiprotocol/zigbee_ble_dynamic_multiprotocol_light/zigbee_ble_dynamic_multiprotocol_light.slcp -d path_to_dest/ --with brd4186c,zigbee_network_test,zigbee_network_steering,bluetooth_on_demand_start,rail_lib_multiprotocol_debug,bluetooth_host_debug_libraries,bluetooth_controller_debug_libraries --without toolchain_gcc_lto
+${ELF}                          zigbee_ble_dynamic_multiprotocol_light.out
+${BOARD}                        brd4186c
+${QUANTUM_TIME}                 0.000020
+${RNG_SEED}                     0
+${UART}                         usart0
+${DEFAULT_UART_TIMEOUT}         10
+${EFR32_COMMON_SCRIPT}          tests/platforms/SiLabs/common/stub_util.resc
+${PROMPT}                       DMPLight>
+${PAN_ID}                       0xABCD
+${POWER}                        0
+${CHANNEL}                      15
+${BLE_CHARACTERISTIC_ID}        31
+${NUM_ZIGBEE_PACKETS}           10
+${ENABLE_UI}                    False
+
+
+*** Keywords ***
+Initial Setup
+    Execute Script              ${EFR32_COMMON_SCRIPT}
+    Execute Command             emulation SetGlobalSerialExecution true
+    Execute Command             emulation SetQuantum "${QUANTUM_TIME}"
+    Execute Command             emulation SetAdvanceImmediately true
+    IF  ${RNG_SEED} > 0
+        Execute Command         emulation SetSeed ${RNG_SEED}
+    END
+    ${RNG_SEED}=                Execute Command  emulation GetSeed
+    Log To Console              RNG SEED: ${RNG_SEED}
+    Execute Command             emulation CreateBLEMedium "wireless"
+    Execute Python              sl_add_stub("sl_zigbee_af_stack_status_cb")
+    Execute Python              sl_add_stub("sl_zigbee_af_post_attribute_change_cb")
+    Execute Python              sl_add_stub("enableBleAdvertisements")
+    Set Default Uart Timeout    ${DEFAULT_UART_TIMEOUT}
+    Execute Command             logLevel 3
+
+Create Node
+    [Arguments]  ${machine_name}
+    [Return]     ${tester_id}
+    Execute Command             mach clear
+    Execute Command             mach create "${machine_name}"
+    Execute Command             machine LoadPlatformDescription @platforms/boards/silabs/${BOARD}.repl
+    Execute Command             sysbus LoadELF @${ELF}
+    Execute Command             sysbus.cpu VectorTableOffset `sysbus GetSymbolAddress "__Vectors"`
+    Execute Command             sysbus LogAllPeripheralsAccess false
+    Execute Command             connector Connect sysbus.radio wireless
+    Execute Python              sl_add_hooks()
+    ${tester_id}=               Create Terminal Tester  sysbus.${UART}  machine=${machine_name}  defaultPauseEmulation=true  defaultWaitForEcho=false
+    # This command togehter with using the "--enable-xwt" option when launching renote-test 
+    # pops up a UART shell for each node and allows to see the nodes CLI activity.
+    IF  ${ENABLE_UI}
+        Execute Command             showAnalyzer sysbus.${UART}
+    END
+    Execute Command             logLevel 3
+    
+Restart Ble Stack
+    [Arguments]  ${tester}
+    [Return]     ${ble_id}
+    Write Line To Uart      plugin ble stop  testerId=${tester}
+    Wait For Line On Uart   Stopping Bluetooth Stack: success  testerId=${tester}
+    Write Line To Uart      plugin ble start  testerId=${tester}
+    Wait For Line On Uart   BLE hello: success  testerId=${tester}
+
+    ${s}=                       Wait For Line On Uart  BLE address: [  testerId=${tester}
+    ${ble_id}=                  Get Substring  ${s.line}  -18  -1
+    Write Line To Uart          plugin ble gap set-conn-params 0x00C8 0x00C8 0x0000 0x0064  testerId=${tester}
+    Wait For Line On Uart       success  testerId=${tester}
+
+Start Ble Advertising 
+    [Arguments]  ${tester}         
+    Write Line To Uart          plugin ble gap set-mode 0 2 2  testerId=${tester}
+    Wait For Line On Uart       success  testerId=${tester}
+
+Create Ble Connection
+    [Arguments]  ${tester}  ${peer_addr}
+    Write Line To Uart          plugin ble gap conn-open {${peer_addr}} 0  testerId=${tester}
+    Wait For Line On Uart       success  testerId=${tester}
+    Wait For Line On Uart       BLE connection opened  testerId=${tester}
+
+Check Ble Connection
+    [Arguments]  ${tester}  ${peer_addr}
+    Write Line To Uart          plugin ble gap print-connections  testerId=${tester}
+    Wait For Line On Uart       Connection Info  testerId=${tester}
+    Wait For Line On Uart       BLE address: [${peer_addr}]  testerId=${tester}
+
+Get Ble Connection Handle
+    [Arguments]  ${tester}  ${peer_addr}
+    [Return]     ${connection_handle}
+    Write Line To Uart          plugin ble gap print-connections  testerId=${tester}
+    Wait For Line On Uart       Connection Info  testerId=${tester}
+    ${s}=                       Wait For Line On Uart  connection handle  testerId=${tester}
+    ${connection_handle}=       Get Substring  ${s.line}  -4
+    Wait For Line On Uart       BLE address: [${peer_addr}]  testerId=${tester}
+
+Send Ble Test Message
+    [Arguments]  ${tx_tester}  ${rx_tester}  ${connection_handle}  ${value}
+    Write Line To Uart          plugin ble gatt write-characteristic ${connection_handle} ${BLE_CHARACTERISTIC_ID} {0${value}}  testerId=${tx_tester}
+    Wait For Line On Uart       success  testerId=${tx_tester}
+    Wait For Line On Uart       Light state write; ${value}  testerId=${rx_tester}
+
+Form Zigbee Network
+    [Arguments]  ${pan_id}  ${power}  ${channel}  ${tester}
+    [Return]     ${short_id}
+    Write Line To Uart          plugin network-creator form 0 ${pan_id} ${power} ${channel}  testerId=${tester}
+    ${s}=                       Wait For Line On Uart  NETWORK_UP  testerId=${tester}
+    ${short_id}=                Get Substring  ${s.line}  -7
+
+Join Zigbee Network
+    [Arguments]  ${tester}
+    [Return]     ${short_id}
+    Write Line To Uart          plugin network-steering start 1  testerId=${tester}
+    Wait For Line On Uart       NWK Steering: Start:  testerId=${tester}
+    ${s}=                       Wait For Line On Uart  NETWORK_UP  testerId=${tester}
+    ${short_id}=                Get Substring  ${s.line}  -7
+    Wait For Line On Uart       Join Success (0x00)  testerId=${tester}
+
+Open Zigbee Network
+    [Arguments]  ${tester}
+    Write Line To Uart          plugin network-creator-security open-network  testerId=${tester}
+    Wait For Line On Uart       Open network: 0x00  testerId=${tester}
+    Wait For Line On Uart       NETWORK_OPENED  testerId=${tester}
+
+Leave Zigbee Network
+    [Arguments]  ${tester}
+    Write Line To Uart          plugin network-steering stop  testerId=${tester}
+    Wait For Line On Uart       NWK Steering: Stop  testerId=${tester}
+    Write Line To Uart          plugin network-creator stop  testerId=${tester}
+    Wait For Line On Uart       NWK Creator: Stop  testerId=${tester}
+    Write Line To Uart          network leave  testerId=${tester}
+    ${s}=                       Wait For Line On Uart  leave 0x  testerId=${tester}
+    ${network_left}=            Run Keyword And Return Status  Should Contain  ${s.line}  0x0
+    IF  ${network_left} == True
+        Wait For Line On Uart   NETWORK_DOWN  testerId=${tester}
+    END
+
+Send Zigbee Test Message
+    [Arguments]  ${tx_tester}  ${rx_tester}  ${rx_tester_short_id}
+    Write Line To Uart          zcl global read 0x0006 0x0  testerId=${tx_tester}
+    Wait For Line On Uart       buffer  testerId=${tx_tester}
+    Write Line To Uart          send ${rx_tester_short_id} 1 1  testerId=${tx_tester}
+    Wait For Line On Uart       RX len 5, ep 01, clus 0x0006 (On/off)  testerId=${rx_tester}
+    Wait For Line On Uart       READ_ATTR: clus 0006  testerId=${rx_tester}
+
+Run Zigbee Throughput Test
+    [Arguments]  ${tx_tester}  ${rx_tester_short_id}
+    Write Line To Uart          network_test start_zigbee_test 70 ${NUM_ZIGBEE_PACKETS} 0 3 ${rx_tester_short_id} 0x00  testerId=${tx_tester}
+    Wait For Line On Uart       ZigBee TX test started  testerId=${tx_tester}
+    ${s}=                       Wait For Line On Uart  Success messages:  testerId=${tx_tester}
+    ${packet_stats}=            Get Regexp Matches  ${s.line}  \\d+
+    ${passingStr}=              Get From List  ${packet_stats}  0
+    ${passing}=                 Convert To Number  ${passing_str}
+    ${totalStr}=                Get From List  ${packet_stats}  1
+    ${total}=                   Convert To Number  ${total_str}
+    ${passRate}=                Evaluate  ${passing} / ${total}
+    Should Be True              ${passRate} >= 0.8
+
+
+*** Test Cases ***
+Zigbee BLE Dynamic Multiprotocol Test
+    Initial Setup
+
+    ${NODE1_TESTER_ID}=         Create Node  node1
+    ${NODE2_TESTER_ID}=         Create Node  node2
+
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE1_TESTER_ID}
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE2_TESTER_ID}
+
+    ${NODE1_SHORT_ID}=          Form Zigbee Network  ${PAN_ID}  ${POWER}  ${CHANNEL}  ${NODE1_TESTER_ID}
+    Open Zigbee Network         ${NODE1_TESTER_ID}
+    ${NODE2_SHORT_ID}=          Join Zigbee Network  ${NODE2_TESTER_ID}
+
+    Run Zigbee Throughput Test  ${NODE1_TESTER_ID}  ${NODE2_SHORT_ID}
+    Run Zigbee Throughput Test  ${NODE2_TESTER_ID}  ${NODE1_SHORT_ID}
+
+    ${NODE1_BLE_ID}=            Restart Ble Stack  ${NODE1_TESTER_ID}
+    ${NODE2_BLE_ID}=            Restart Ble Stack  ${NODE2_TESTER_ID}
+    Start Ble Advertising       ${NODE2_TESTER_ID}
+    Create Ble Connection       ${NODE1_TESTER_ID}  ${NODE2_BLE_ID}
+
+    Check Ble Connection        ${NODE1_TESTER_ID}  ${NODE2_BLE_ID}
+    Check Ble Connection        ${NODE2_TESTER_ID}  ${NODE1_BLE_ID}
+
+    ${NODE1_CONN_HANDLE}=       Get Ble Connection Handle  ${NODE1_TESTER_ID}  ${NODE2_BLE_ID}
+    ${NODE2_CONN_HANDLE}=       Get Ble Connection Handle  ${NODE2_TESTER_ID}  ${NODE1_BLE_ID}
+
+    Send Ble Test Message       ${NODE1_TESTER_ID}  ${NODE2_TESTER_ID}  ${NODE1_CONN_HANDLE}  1
+    Send Ble Test Message       ${NODE2_TESTER_ID}  ${NODE1_TESTER_ID}  ${NODE2_CONN_HANDLE}  0
+
+    Run Zigbee Throughput Test  ${NODE1_TESTER_ID}  ${NODE2_SHORT_ID}
+    Run Zigbee Throughput Test  ${NODE2_TESTER_ID}  ${NODE1_SHORT_ID}
+
+    Leave Zigbee Network        ${NODE1_TESTER_ID}
+    Leave Zigbee Network        ${NODE2_TESTER_ID}
+
+    Check Ble Connection        ${NODE1_TESTER_ID}  ${NODE2_BLE_ID}
+    Check Ble Connection        ${NODE2_TESTER_ID}  ${NODE1_BLE_ID}
+
+    ${NODE2_SHORT_ID}=          Form Zigbee Network  ${PAN_ID}  ${POWER}  ${CHANNEL}  ${NODE2_TESTER_ID}
+    Open Zigbee Network         ${NODE2_TESTER_ID}
+    ${NODE1_SHORT_ID}=          Join Zigbee Network  ${NODE1_TESTER_ID}
+
+    Check Ble Connection        ${NODE1_TESTER_ID}  ${NODE2_BLE_ID}
+    Check Ble Connection        ${NODE2_TESTER_ID}  ${NODE1_BLE_ID}
+
+    Run Zigbee Throughput Test  ${NODE1_TESTER_ID}  ${NODE2_SHORT_ID}
+    Run Zigbee Throughput Test  ${NODE2_TESTER_ID}  ${NODE1_SHORT_ID}
+
+    Send Ble Test Message       ${NODE1_TESTER_ID}  ${NODE2_TESTER_ID}  ${NODE1_CONN_HANDLE}  0
+    Send Ble Test Message       ${NODE2_TESTER_ID}  ${NODE1_TESTER_ID}  ${NODE2_CONN_HANDLE}  1
+
+    Check Ble Connection        ${NODE1_TESTER_ID}  ${NODE2_BLE_ID}
+    Check Ble Connection        ${NODE2_TESTER_ID}  ${NODE1_BLE_ID}

--- a/tests/platforms/SiLabs/ble_ncp.py
+++ b/tests/platforms/SiLabs/ble_ncp.py
@@ -1,0 +1,58 @@
+from common import test_lib
+from common import bgapi_lib
+
+################################################
+# Globals
+################################################
+
+QUANTUM_TIME = 0.000020
+DEBUG = True
+
+################################################
+# Utility functions
+################################################
+
+################################################
+# Test
+################################################
+
+board, uart, elf = test_lib.parse_arguments()
+test_lib.create_emulation(debug=DEBUG, quantum_time=QUANTUM_TIME)
+
+# Node 1 
+ncp1 = test_lib.create_node("ncp1", board, elf, uart)
+test_lib.create_socket(ncp1, 3451, uart)
+host1 = bgapi_lib.open_host_connection(3451)
+
+# Node 2
+ncp2 = test_lib.create_node("ncp2", board, elf, uart)
+test_lib.create_socket(ncp2, 3452, uart)
+host2 = bgapi_lib.open_host_connection(3452)
+
+bgapi_lib.wait_for_boot_event(host1)
+bgapi_lib.wait_for_boot_event(host2)
+
+bgapi_lib.cmd_hello(host1)
+bgapi_lib.cmd_hello(host2)
+
+node1_address = bgapi_lib.cmd_get_identity_address(host1)
+node2_address = bgapi_lib.cmd_get_identity_address(host2)
+
+# Node 1 to start advertising
+adv_handle = bgapi_lib.cmd_legacy_advertiser_create_set(host1)
+bgapi_lib.cmd_legacy_advertiser_generate_data(host1, adv_handle, 2)
+bgapi_lib.cmd_legacy_advertiser_start(host1, adv_handle, 2)
+
+# Node 2 to establish a connection to Node 1
+bgapi_lib.cmd_connection_open(host2, node1_address, 0)
+node1_conn_handle = bgapi_lib.wait_for_connection_opened_event(host1)
+node2_conn_handle = bgapi_lib.wait_for_connection_opened_event(host2)
+
+bgapi_lib.assert_no_connection_closed_event(host1)
+bgapi_lib.assert_no_connection_closed_event(host2)
+
+# Let some time pass and check that the connection is still open
+test_lib.delay(3)
+
+bgapi_lib.assert_no_connection_closed_event(host1)
+bgapi_lib.assert_no_connection_closed_event(host2)

--- a/tests/platforms/SiLabs/common/bgapi_lib.py
+++ b/tests/platforms/SiLabs/common/bgapi_lib.py
@@ -1,0 +1,117 @@
+from common import bgapi_lib
+from common import test_lib
+import bgapi
+
+XAPI = "tests/platforms/SiLabs/common/sl_bt.xapi"
+DEFAULT_TIMEOUT = 2
+DEFAULT_INTERVAL = 0.1
+
+terminal_testers = {}
+
+########################################################################
+# BGAPI Commands
+########################################################################
+
+def cmd_hello(tester_id):
+    _execute_command(tester_id, "system.hello")
+
+def cmd_get_identity_address(tester_id):
+    return _execute_command(tester_id, "system.get_identity_address").address
+
+def cmd_legacy_advertiser_create_set(tester_id):
+    return int(_execute_command(tester_id, "advertiser.create_set").handle)
+
+def cmd_legacy_advertiser_generate_data(tester_id, handle, mode):
+    _execute_command(tester_id, "legacy_advertiser.generate_data", handle, mode)
+
+def cmd_legacy_advertiser_start(tester_id, handle, mode):
+    _execute_command(tester_id, "legacy_advertiser.start", handle, mode)
+
+########################################################################
+# Events
+########################################################################
+
+def wait_for_boot_event(tester_id):
+    return _wait_for_event("bt_evt_system_boot", tester_id)
+
+def wait_for_connection_opened_event(tester_id):
+    result = _wait_for_event("bt_evt_connection_opened", tester_id)
+    return result.connection
+
+def cmd_connection_open(tester_id, address, address_type):
+    l = _host_connection_lookup(tester_id)
+    return _execute_command(tester_id, "connection.open", address, address_type, l.bt.gap.PHY_PHY_1M).connection
+
+def assert_no_connection_closed_event(tester_id):
+    assert_event_not_in_queue(tester_id, "bt_evt_connection_opened")
+
+def assert_event_not_in_queue(tester_id, event):
+    while _get_pending_event(tester_id):
+        if _get_pending_event(tester_id) == event:
+            test_lib.fail(f"Unexpected event in queue: {event}")
+    test_lib.debug_print(f"Confirmed event \"{event}\" not in queue")
+
+########################################################################
+# Host Connection
+########################################################################
+
+def open_host_connection(port):
+    global terminal_testers
+    connector = bgapi.SocketConnector("127.0.0.1", port)
+    l = bgapi.BGLib(connector, XAPI, response_timeout=10)
+    l.open()
+    test_lib.debug_print(f"Opened host connection on port: {port}")
+    index = len(terminal_testers)
+    terminal_testers[index] = l
+    return index
+
+def close_all_host_connections():
+    for i in terminal_testers:
+        terminal_testers[i].close()
+
+########################################################################
+# Internals
+########################################################################
+
+def _host_connection_lookup(index):
+    for i in terminal_testers:
+        if index == i:
+            return terminal_testers[i]
+    return None
+
+def _get_pending_event(tester_id):
+    l = _host_connection_lookup(tester_id)
+    for e in l.gen_events():
+        return e
+    return None
+
+def _execute_command(tester_id, command, *args):
+    l = _host_connection_lookup(tester_id)
+    test_lib.monitor().execute("start")
+    attrs = command.split(".")
+    obj = l.bt
+    for attr in attrs:
+        obj = getattr(obj, attr)
+    test_lib.debug_print(f"Executing command: {command}, with args: {args}")
+    response = obj(*args)
+    test_lib.debug_print(f"Command response: {response}")
+    test_lib.monitor().execute("pause")
+    if (response.result != 0):
+        test_lib.fail(f"\"{command}\" command: response unsuccessful: {response.result}")
+    return response
+
+def _wait_for_event(event, tester_id):
+    max_attempts = DEFAULT_TIMEOUT / DEFAULT_INTERVAL
+    attempts = 0
+    for attempts in range(int(max_attempts)):
+        evt = _get_pending_event(tester_id)
+        test_lib.debug_print(f"Waiting for event: {event}, Current event: {evt}")
+        if evt == None:
+            test_lib.delay(DEFAULT_INTERVAL)
+        else:
+            if evt == event:
+                return evt
+            else:
+                test_lib.fail(f"Event mismatch: {evt} != {event}")
+    test_lib.fail(f"Timeout waiting for event: {event}")
+    return None

--- a/tests/platforms/SiLabs/common/sl_bt.xapi
+++ b/tests/platforms/SiLabs/common/sl_bt.xapi
@@ -1,0 +1,3705 @@
+<?xml version="1.0" ?>
+<api device_id="4" device_name="bt" version="9.0.0">
+    <datatypes>
+        <datatype base="uint16" name="errorcode" length="2"/>
+        <datatype base="int16" name="int16" length="2"/>
+        <datatype base="bd_addr" name="bd_addr" length="6"/>
+        <datatype base="uint16" name="uint16" length="2"/>
+        <datatype base="int32" name="int32" length="4"/>
+        <datatype base="uint32" name="uint32" length="4"/>
+        <datatype base="uint16" name="link_id_t" length="2"/>
+        <datatype base="int8" name="int8" length="1"/>
+        <datatype base="uint8" name="uint8" length="1"/>
+        <datatype base="uint8array" name="uint8array" length="1"/>
+        <datatype base="uint16array" name="uint16array" length="2"/>
+        <datatype base="byte_array" name="byte_array" length="0"/>
+        <datatype base="ser_name" name="ser_name" length="16"/>
+        <datatype base="int8" name="dbm" length="1"/>
+        <datatype base="uint8" name="connection" length="1"/>
+        <datatype base="uint32" name="att_bearer" length="4"/>
+        <datatype base="uint32" name="service" length="4"/>
+        <datatype base="uint16" name="characteristic" length="2"/>
+        <datatype base="uint16" name="descriptor" length="2"/>
+        <datatype base="uint16" name="attribute_handle" length="2"/>
+        <datatype base="uint8array" name="uuid" length="1"/>
+        <datatype base="uint8" name="att_errorcode" length="1"/>
+        <datatype base="uint8" name="att_opcode" length="1"/>
+        <datatype base="uuid_128" name="uuid_128" length="16"/>
+        <datatype base="aes_key_128" name="aes_key_128" length="16"/>
+        <datatype base="byte_array" name="cs_subevent_length" length="3"/>
+        <datatype base="byte_array" name="drbg_key" length="16"/>
+        <datatype base="byte_array" name="cs_channel_map" length="10"/>
+        <datatype base="byte_array" name="connection_channel_map" length="5"/>
+        <datatype base="sl_bt_uuid_16_t" name="uuid_16" length="2"/>
+        <datatype base="sl_bt_uuid_64_t" name="uuid_64" length="8"/>
+        <datatype base="int64" name="int64" length="8"/>
+        <datatype base="uint64" name="uint64" length="8"/>
+    </datatypes>
+    <class index="0" name="dfu">
+        <command index="1" name="flash_set_address" >
+            <params>
+                <param datatype="uint32" name="address" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="flash_upload" >
+            <params>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="flash_upload_finish" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="boot">
+            <params>
+                <param datatype="uint32" name="version" type="uint32"/>
+            </params>
+        </event>
+        <event index="1" name="boot_failure">
+            <params>
+                <param datatype="errorcode" name="reason" type="uint16"/>
+            </params>
+        </event>
+    </class>
+    <class index="1" name="system">
+        <command index="0" name="hello" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="28" name="start_bluetooth" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="29" name="stop_bluetooth" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="30" name="forcefully_stop_bluetooth" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="27" name="get_version" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="major" type="uint16"/>
+                <param datatype="uint16" name="minor" type="uint16"/>
+                <param datatype="uint16" name="patch" type="uint16"/>
+                <param datatype="uint16" name="build" type="uint16"/>
+                <param datatype="uint32" name="bootloader" type="uint32"/>
+                <param datatype="uint32" name="hash" type="uint32"/>
+            </returns>
+        </command>
+        <command index="31" name="reboot" no_return="true">
+            <params/>
+        </command>
+        <command index="12" name="halt" >
+            <params>
+                <param datatype="uint8" name="halt" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="14" name="linklayer_configure" >
+            <params>
+                <param datatype="uint8" name="key" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="23" name="set_tx_power" >
+            <params>
+                <param datatype="int16" name="min_power" type="int16"/>
+                <param datatype="int16" name="max_power" type="int16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="int16" name="set_min" type="int16"/>
+                <param datatype="int16" name="set_max" type="int16"/>
+            </returns>
+        </command>
+        <command index="24" name="get_tx_power_setting" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="int16" name="support_min" type="int16"/>
+                <param datatype="int16" name="support_max" type="int16"/>
+                <param datatype="int16" name="set_min" type="int16"/>
+                <param datatype="int16" name="set_max" type="int16"/>
+                <param datatype="int16" name="rf_path_gain" type="int16"/>
+            </returns>
+        </command>
+        <command index="19" name="set_identity_address" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="21" name="get_identity_address" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+            </returns>
+        </command>
+        <command index="11" name="get_random_data" >
+            <params>
+                <param datatype="uint8" name="length" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </returns>
+        </command>
+        <command index="18" name="data_buffer_write" >
+            <params>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="20" name="data_buffer_clear" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="15" name="get_counters" >
+            <params>
+                <param datatype="uint8" name="reset" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="tx_packets" type="uint16"/>
+                <param datatype="uint16" name="rx_packets" type="uint16"/>
+                <param datatype="uint16" name="crc_errors" type="uint16"/>
+                <param datatype="uint16" name="failures" type="uint16"/>
+            </returns>
+        </command>
+        <command index="26" name="set_lazy_soft_timer" >
+            <params>
+                <param datatype="uint32" name="time" type="uint32"/>
+                <param datatype="uint32" name="slack" type="uint32"/>
+                <param datatype="uint8" name="handle" type="uint8"/>
+                <param datatype="uint8" name="single_shot" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="reset" no_return="true">
+            <params>
+                <param datatype="uint8" name="dfu" type="uint8"/>
+            </params>
+        </command>
+        <event index="0" name="boot">
+            <params>
+                <param datatype="uint16" name="major" type="uint16"/>
+                <param datatype="uint16" name="minor" type="uint16"/>
+                <param datatype="uint16" name="patch" type="uint16"/>
+                <param datatype="uint16" name="build" type="uint16"/>
+                <param datatype="uint32" name="bootloader" type="uint32"/>
+                <param datatype="uint16" name="hw" type="uint16"/>
+                <param datatype="uint32" name="hash" type="uint32"/>
+            </params>
+        </event>
+        <event index="1" name="stopped">
+            <params/>
+        </event>
+        <event index="6" name="error">
+            <params>
+                <param datatype="errorcode" name="reason" type="uint16"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+        <event index="8" name="resource_exhausted">
+            <params>
+                <param datatype="uint8" name="num_buffers_discarded" type="uint8"/>
+                <param datatype="uint8" name="num_buffer_allocation_failures" type="uint8"/>
+                <param datatype="uint8" name="num_heap_allocation_failures" type="uint8"/>
+                <param datatype="uint8" name="num_message_allocation_failures" type="uint8"/>
+            </params>
+        </event>
+        <event index="3" name="external_signal">
+            <params>
+                <param datatype="uint32" name="extsignals" type="uint32"/>
+            </params>
+        </event>
+        <event index="4" name="awake">
+            <params/>
+        </event>
+        <event index="7" name="soft_timer">
+            <params>
+                <param datatype="uint8" name="handle" type="uint8"/>
+            </params>
+        </event>
+        <enums name="linklayer_config_key">
+            <enum name="linklayer_config_key_halt" value="0x1"/>
+            <enum name="linklayer_config_key_priority_range" value="0x2"/>
+            <enum name="linklayer_config_key_scan_channels" value="0x3"/>
+            <enum name="linklayer_config_key_set_flags" value="0x4"/>
+            <enum name="linklayer_config_key_clr_flags" value="0x5"/>
+            <enum name="linklayer_config_key_set_afh_interval" value="0x7"/>
+            <enum name="linklayer_config_key_set_periodic_advertising_status_report" value="0x8"/>
+            <enum name="linklayer_config_key_set_priority_table" value="0x9"/>
+            <enum name="linklayer_config_key_set_rx_packet_filtering" value="0xa"/>
+            <enum name="linklayer_config_key_set_simultaneous_scanning" value="0xb"/>
+            <enum name="linklayer_config_key_set_channelmap_flags" value="0xc"/>
+            <enum name="linklayer_config_key_low_power_mode_power_limit" value="0xd"/>
+            <enum name="linklayer_config_key_power_control_golden_range" value="0x10"/>
+            <enum name="linklayer_config_key_active_scanner_backoff_upper_limit" value="0x11"/>
+            <enum name="linklayer_config_key_afh_rssi_threshold" value="0x12"/>
+            <enum name="linklayer_config_key_afh_channel_cooldown" value="0x13"/>
+            <enum name="linklayer_config_key_set_report_all_scan_rsps" value="0x14"/>
+        </enums>
+    </class>
+    <class index="95" name="resource">
+        <command index="0" name="get_status" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint32" name="total_bytes" type="uint32"/>
+                <param datatype="uint32" name="free_bytes" type="uint32"/>
+            </returns>
+        </command>
+        <command index="1" name="set_report_threshold" >
+            <params>
+                <param datatype="uint32" name="low" type="uint32"/>
+                <param datatype="uint32" name="high" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="enable_connection_tx_report" >
+            <params>
+                <param datatype="uint16" name="packet_count" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="get_connection_tx_status" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="flags" type="uint16"/>
+                <param datatype="uint16" name="packet_count" type="uint16"/>
+                <param datatype="uint32" name="data_len" type="uint32"/>
+            </returns>
+        </command>
+        <command index="4" name="disable_connection_tx_report" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="status">
+            <params>
+                <param datatype="uint32" name="free_bytes" type="uint32"/>
+            </params>
+        </event>
+        <defines name="connection_tx_flags">
+            <define name="connection_tx_flags_error_packet_overflow" value="0x1"/>
+            <define name="connection_tx_flags_error_corrupt" value="0x2"/>
+        </defines>
+    </class>
+    <class index="2" name="gap">
+        <command index="1" name="set_privacy_mode" >
+            <params>
+                <param datatype="uint8" name="privacy" type="uint8"/>
+                <param datatype="uint8" name="interval" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="set_data_channel_classification" >
+            <params>
+                <param datatype="uint8array" name="channel_map" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="set_identity_address" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="addr_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="get_identity_address" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+            </returns>
+        </command>
+        <enums name="address_type">
+            <enum name="public_address" value="0x0"/>
+            <enum name="static_address" value="0x1"/>
+            <enum name="random_resolvable_address" value="0x2"/>
+            <enum name="random_nonresolvable_address" value="0x3"/>
+            <enum name="public_address_resolved_from_rpa" value="0x4"/>
+            <enum name="static_address_resolved_from_rpa" value="0x5"/>
+            <enum name="anonymous_address" value="0xff"/>
+        </enums>
+        <enums name="phy">
+            <enum name="phy_1m" value="0x1"/>
+            <enum name="phy_2m" value="0x2"/>
+            <enum name="phy_coded" value="0x4"/>
+            <enum name="phy_any" value="0xff"/>
+        </enums>
+        <enums name="phy_coding">
+            <enum name="phy_coding_1m_uncoded" value="0x1"/>
+            <enum name="phy_coding_2m_uncoded" value="0x2"/>
+            <enum name="phy_coding_125k_coded" value="0x4"/>
+            <enum name="phy_coding_500k_coded" value="0x8"/>
+        </enums>
+        <enums name="channel_selection_algorithm">
+            <enum name="channel_selection_algorithm_1" value="0x0"/>
+            <enum name="channel_selection_algorithm_2" value="0x1"/>
+        </enums>
+    </class>
+    <class index="4" name="advertiser">
+        <command index="1" name="create_set" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="handle" type="uint8"/>
+            </returns>
+        </command>
+        <command index="18" name="configure" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint32" name="flags" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="set_timing" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint32" name="interval_min" type="uint32"/>
+                <param datatype="uint32" name="interval_max" type="uint32"/>
+                <param datatype="uint16" name="duration" type="uint16"/>
+                <param datatype="uint8" name="maxevents" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="set_channel_map" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="channel_map" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="11" name="set_tx_power" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="int16" name="power" type="int16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="int16" name="set_power" type="int16"/>
+            </returns>
+        </command>
+        <command index="5" name="set_report_scan_request" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="report_scan_req" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="16" name="set_random_address" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="addr_type" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="bd_addr" name="address_out" type="bd_addr"/>
+            </returns>
+        </command>
+        <command index="17" name="clear_random_address" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="10" name="stop" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="delete_set" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="1" name="timeout">
+            <params>
+                <param datatype="uint8" name="handle" type="uint8"/>
+            </params>
+        </event>
+        <event index="2" name="scan_request">
+            <params>
+                <param datatype="uint8" name="handle" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+            </params>
+        </event>
+        <enums name="discovery_mode">
+            <enum name="non_discoverable" value="0x0"/>
+            <enum name="limited_discoverable" value="0x1"/>
+            <enum name="general_discoverable" value="0x2"/>
+        </enums>
+        <enums name="adv_address_type">
+            <enum name="identity_address" value="0x0"/>
+            <enum name="non_resolvable" value="0x1"/>
+        </enums>
+        <enums name="packet_type">
+            <enum name="advertising_data_packet" value="0x0"/>
+            <enum name="scan_response_packet" value="0x1"/>
+        </enums>
+        <defines name="flags">
+            <define name="use_nonresolvable_address" value="0x4"/>
+            <define name="use_device_identity_in_privacy" value="0x10"/>
+            <define name="use_filter_for_scan_requests" value="0x20"/>
+            <define name="use_filter_for_connection_requests" value="0x40"/>
+        </defines>
+    </class>
+    <class index="86" name="legacy_advertiser">
+        <command index="0" name="set_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="generate_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="discover" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="start" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="connect" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="start_directed" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="connect" type="uint8"/>
+                <param datatype="bd_addr" name="peer_addr" type="bd_addr"/>
+                <param datatype="uint8" name="peer_addr_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <enums name="connection_mode">
+            <enum name="non_connectable" value="0x0"/>
+            <enum name="connectable" value="0x2"/>
+            <enum name="scannable" value="0x3"/>
+        </enums>
+        <enums name="directed_connection_mode">
+            <enum name="high_duty_directed_connectable" value="0x1"/>
+            <enum name="low_duty_directed_connectable" value="0x5"/>
+        </enums>
+    </class>
+    <class index="87" name="extended_advertiser">
+        <command index="0" name="set_phy" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="primary_phy" type="uint8"/>
+                <param datatype="uint8" name="secondary_phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="set_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="set_long_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="generate_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="discover" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="start" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="connect" type="uint8"/>
+                <param datatype="uint32" name="flags" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="start_directed" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="connect" type="uint8"/>
+                <param datatype="uint32" name="flags" type="uint32"/>
+                <param datatype="bd_addr" name="peer_addr" type="bd_addr"/>
+                <param datatype="uint8" name="peer_addr_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <enums name="connection_mode">
+            <enum name="non_connectable" value="0x0"/>
+            <enum name="scannable" value="0x3"/>
+            <enum name="connectable" value="0x4"/>
+        </enums>
+        <defines name="flags">
+            <define name="anonymous_advertising" value="0x1"/>
+            <define name="include_tx_power" value="0x2"/>
+        </defines>
+    </class>
+    <class index="88" name="periodic_advertiser">
+        <command index="0" name="set_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="set_long_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="start" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint16" name="interval_min" type="uint16"/>
+                <param datatype="uint16" name="interval_max" type="uint16"/>
+                <param datatype="uint32" name="flags" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="stop" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="status">
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint32" name="status" type="uint32"/>
+                <param datatype="uint16" name="event_counter" type="uint16"/>
+            </params>
+        </event>
+        <defines name="flags">
+            <define name="include_tx_power" value="0x1"/>
+            <define name="auto_start_extended_advertising" value="0x2"/>
+        </defines>
+    </class>
+    <class index="5" name="scanner">
+        <command index="6" name="set_parameters" >
+            <params>
+                <param datatype="uint8" name="mode" type="uint8"/>
+                <param datatype="uint16" name="interval" type="uint16"/>
+                <param datatype="uint16" name="window" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="7" name="set_parameters_and_filter" >
+            <params>
+                <param datatype="uint8" name="mode" type="uint8"/>
+                <param datatype="uint16" name="interval" type="uint16"/>
+                <param datatype="uint16" name="window" type="uint16"/>
+                <param datatype="uint32" name="flags" type="uint32"/>
+                <param datatype="uint8" name="filter_policy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="start" >
+            <params>
+                <param datatype="uint8" name="scanning_phy" type="uint8"/>
+                <param datatype="uint8" name="discover_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="stop" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="legacy_advertisement_report">
+            <params>
+                <param datatype="uint8" name="event_flags" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="bd_addr" name="target_address" type="bd_addr"/>
+                <param datatype="uint8" name="target_address_type" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+        <event index="2" name="extended_advertisement_report">
+            <params>
+                <param datatype="uint8" name="event_flags" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="bd_addr" name="target_address" type="bd_addr"/>
+                <param datatype="uint8" name="target_address_type" type="uint8"/>
+                <param datatype="uint8" name="adv_sid" type="uint8"/>
+                <param datatype="uint8" name="primary_phy" type="uint8"/>
+                <param datatype="uint8" name="secondary_phy" type="uint8"/>
+                <param datatype="int8" name="tx_power" type="int8"/>
+                <param datatype="uint16" name="periodic_interval" type="uint16"/>
+                <param datatype="uint8" name="data_completeness" type="uint8"/>
+                <param datatype="uint8" name="counter" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+        <enums name="discover_mode">
+            <enum name="discover_limited" value="0x0"/>
+            <enum name="discover_generic" value="0x1"/>
+            <enum name="discover_observation" value="0x2"/>
+        </enums>
+        <enums name="scan_mode">
+            <enum name="scan_mode_passive" value="0x0"/>
+            <enum name="scan_mode_active" value="0x1"/>
+        </enums>
+        <enums name="scan_phy">
+            <enum name="scan_phy_1m" value="0x1"/>
+            <enum name="scan_phy_coded" value="0x4"/>
+            <enum name="scan_phy_1m_and_coded" value="0x5"/>
+        </enums>
+        <enums name="data_status">
+            <enum name="data_status_complete" value="0x0"/>
+            <enum name="data_status_incomplete_more" value="0x1"/>
+            <enum name="data_status_incomplete_nomore" value="0x2"/>
+        </enums>
+        <enums name="filter_policy">
+            <enum name="filter_policy_basic_unfiltered" value="0x0"/>
+            <enum name="filter_policy_basic_filtered" value="0x1"/>
+            <enum name="filter_policy_extended_unfiltered" value="0x2"/>
+            <enum name="filter_policy_extended_filtered" value="0x3"/>
+        </enums>
+        <defines name="event_flag">
+            <define name="event_flag_connectable" value="0x1"/>
+            <define name="event_flag_scannable" value="0x2"/>
+            <define name="event_flag_directed" value="0x4"/>
+            <define name="event_flag_scan_response" value="0x8"/>
+        </defines>
+        <defines name="option_flags">
+            <define name="ignore_bonding" value="0x1"/>
+        </defines>
+    </class>
+    <class index="66" name="sync">
+        <command index="3" name="set_reporting_mode" >
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint8" name="reporting_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="update_sync_parameters" >
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint16" name="skip" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="close" >
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="1" name="closed">
+            <params>
+                <param datatype="errorcode" name="reason" type="uint16"/>
+                <param datatype="uint16" name="sync" type="uint16"/>
+            </params>
+        </event>
+        <enums name="reporting_mode">
+            <enum name="report_none" value="0x0"/>
+            <enum name="report_all" value="0x1"/>
+        </enums>
+        <enums name="advertiser_clock_accuracy">
+            <enum name="clock_accuracy_500" value="0x1f4"/>
+            <enum name="clock_accuracy_250" value="0xfa"/>
+            <enum name="clock_accuracy_150" value="0x96"/>
+            <enum name="clock_accuracy_100" value="0x64"/>
+            <enum name="clock_accuracy_75" value="0x4b"/>
+            <enum name="clock_accuracy_50" value="0x32"/>
+            <enum name="clock_accuracy_30" value="0x1e"/>
+            <enum name="clock_accuracy_20" value="0x14"/>
+        </enums>
+    </class>
+    <class index="80" name="sync_scanner">
+        <command index="0" name="set_sync_parameters" >
+            <params>
+                <param datatype="uint16" name="skip" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint8" name="reporting_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="open" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="adv_sid" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="sync" type="uint16"/>
+            </returns>
+        </command>
+    </class>
+    <class index="81" name="past_receiver">
+        <command index="0" name="set_default_sync_receive_parameters" >
+            <params>
+                <param datatype="uint8" name="mode" type="uint8"/>
+                <param datatype="uint16" name="skip" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint8" name="reporting_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="set_sync_receive_parameters" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="mode" type="uint8"/>
+                <param datatype="uint16" name="skip" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint8" name="reporting_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <enums name="mode">
+            <enum name="mode_ignore" value="0x0"/>
+            <enum name="mode_synchronize" value="0x1"/>
+        </enums>
+    </class>
+    <class index="82" name="advertiser_past">
+        <command index="0" name="transfer" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="service_data" type="uint16"/>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+    </class>
+    <class index="91" name="sync_past">
+        <command index="0" name="transfer" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="service_data" type="uint16"/>
+                <param datatype="uint16" name="sync" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+    </class>
+    <class index="83" name="periodic_sync">
+        <event index="0" name="opened">
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint8" name="adv_sid" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="adv_phy" type="uint8"/>
+                <param datatype="uint16" name="adv_interval" type="uint16"/>
+                <param datatype="uint16" name="clock_accuracy" type="uint16"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+            </params>
+        </event>
+        <event index="1" name="transfer_received">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint16" name="service_data" type="uint16"/>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="adv_sid" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="adv_phy" type="uint8"/>
+                <param datatype="uint16" name="adv_interval" type="uint16"/>
+                <param datatype="uint16" name="clock_accuracy" type="uint16"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+            </params>
+        </event>
+        <event index="2" name="report">
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="int8" name="tx_power" type="int8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="data_status" type="uint8"/>
+                <param datatype="uint8" name="counter" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+    </class>
+    <class index="84" name="pawr_sync">
+        <command index="2" name="set_sync_subevents" >
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint8array" name="subevents" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="set_response_data" >
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint16" name="request_event" type="uint16"/>
+                <param datatype="uint8" name="request_subevent" type="uint8"/>
+                <param datatype="uint8" name="response_subevent" type="uint8"/>
+                <param datatype="uint8" name="response_slot" type="uint8"/>
+                <param datatype="uint8array" name="response_data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="opened">
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint8" name="adv_sid" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="adv_phy" type="uint8"/>
+                <param datatype="uint16" name="adv_interval" type="uint16"/>
+                <param datatype="uint16" name="clock_accuracy" type="uint16"/>
+                <param datatype="uint8" name="num_subevents" type="uint8"/>
+                <param datatype="uint8" name="subevent_interval" type="uint8"/>
+                <param datatype="uint8" name="response_slot_delay" type="uint8"/>
+                <param datatype="uint8" name="response_slot_spacing" type="uint8"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+            </params>
+        </event>
+        <event index="1" name="transfer_received">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint16" name="service_data" type="uint16"/>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="adv_sid" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="adv_phy" type="uint8"/>
+                <param datatype="uint16" name="adv_interval" type="uint16"/>
+                <param datatype="uint16" name="clock_accuracy" type="uint16"/>
+                <param datatype="uint8" name="num_subevents" type="uint8"/>
+                <param datatype="uint8" name="subevent_interval" type="uint8"/>
+                <param datatype="uint8" name="response_slot_delay" type="uint8"/>
+                <param datatype="uint8" name="response_slot_spacing" type="uint8"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+            </params>
+        </event>
+        <event index="2" name="subevent_report">
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="int8" name="tx_power" type="int8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint16" name="event_counter" type="uint16"/>
+                <param datatype="uint8" name="subevent" type="uint8"/>
+                <param datatype="uint8" name="data_status" type="uint8"/>
+                <param datatype="uint8" name="counter" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+    </class>
+    <class index="85" name="pawr_advertiser">
+        <command index="0" name="start" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint16" name="interval_min" type="uint16"/>
+                <param datatype="uint16" name="interval_max" type="uint16"/>
+                <param datatype="uint32" name="flags" type="uint32"/>
+                <param datatype="uint8" name="num_subevents" type="uint8"/>
+                <param datatype="uint8" name="subevent_interval" type="uint8"/>
+                <param datatype="uint8" name="response_slot_delay" type="uint8"/>
+                <param datatype="uint8" name="response_slot_spacing" type="uint8"/>
+                <param datatype="uint8" name="response_slots" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="set_subevent_data" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="subevent" type="uint8"/>
+                <param datatype="uint8" name="response_slot_start" type="uint8"/>
+                <param datatype="uint8" name="response_slot_count" type="uint8"/>
+                <param datatype="uint8array" name="adv_data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="create_connection" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="subevent" type="uint8"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </returns>
+        </command>
+        <command index="3" name="stop" >
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="subevent_data_request">
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="subevent_start" type="uint8"/>
+                <param datatype="uint8" name="subevent_data_count" type="uint8"/>
+            </params>
+        </event>
+        <event index="2" name="subevent_tx_failed">
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="subevent" type="uint8"/>
+            </params>
+        </event>
+        <event index="1" name="response_report">
+            <params>
+                <param datatype="uint8" name="advertising_set" type="uint8"/>
+                <param datatype="uint8" name="subevent" type="uint8"/>
+                <param datatype="int8" name="tx_power" type="int8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="response_slot" type="uint8"/>
+                <param datatype="uint8" name="data_status" type="uint8"/>
+                <param datatype="uint8" name="counter" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+    </class>
+    <class index="6" name="connection">
+        <command index="0" name="set_default_parameters" >
+            <params>
+                <param datatype="uint16" name="min_interval" type="uint16"/>
+                <param datatype="uint16" name="max_interval" type="uint16"/>
+                <param datatype="uint16" name="latency" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint16" name="min_ce_length" type="uint16"/>
+                <param datatype="uint16" name="max_ce_length" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="set_default_preferred_phy" >
+            <params>
+                <param datatype="uint8" name="preferred_phy" type="uint8"/>
+                <param datatype="uint8" name="accepted_phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="16" name="set_default_data_length" >
+            <params>
+                <param datatype="uint16" name="tx_data_len" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="25" name="set_default_acceptable_subrate" >
+            <params>
+                <param datatype="uint16" name="min_subrate" type="uint16"/>
+                <param datatype="uint16" name="max_subrate" type="uint16"/>
+                <param datatype="uint16" name="max_latency" type="uint16"/>
+                <param datatype="uint16" name="continuation_number" type="uint16"/>
+                <param datatype="uint16" name="max_timeout" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="open" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="initiating_phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </returns>
+        </command>
+        <command index="22" name="open_with_accept_list" >
+            <params>
+                <param datatype="uint8" name="initiating_phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </returns>
+        </command>
+        <command index="6" name="set_parameters" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="min_interval" type="uint16"/>
+                <param datatype="uint16" name="max_interval" type="uint16"/>
+                <param datatype="uint16" name="latency" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint16" name="min_ce_length" type="uint16"/>
+                <param datatype="uint16" name="max_ce_length" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="8" name="set_preferred_phy" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="preferred_phy" type="uint8"/>
+                <param datatype="uint8" name="accepted_phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="disable_slave_latency" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="disable" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="21" name="get_median_rssi" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="int8" name="rssi" type="int8"/>
+            </returns>
+        </command>
+        <command index="7" name="read_channel_map" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8array" name="channel_map" type="uint8array"/>
+            </returns>
+        </command>
+        <command index="9" name="set_power_reporting" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="10" name="set_remote_power_reporting" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="11" name="get_tx_power" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="int8" name="current_level" type="int8"/>
+                <param datatype="int8" name="max_level" type="int8"/>
+            </returns>
+        </command>
+        <command index="12" name="get_remote_tx_power" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="18" name="set_tx_power" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="int16" name="tx_power" type="int16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="int16" name="tx_power_out" type="int16"/>
+            </returns>
+        </command>
+        <command index="13" name="read_remote_used_features" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="14" name="get_security_status" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="security_mode" type="uint8"/>
+                <param datatype="uint8" name="key_size" type="uint8"/>
+                <param datatype="uint8" name="bonding_handle" type="uint8"/>
+            </returns>
+        </command>
+        <command index="17" name="set_data_length" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="tx_data_len" type="uint16"/>
+                <param datatype="uint16" name="tx_time_us" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="19" name="read_statistics" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="reset" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="20" name="get_scheduling_details" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint32" name="access_address" type="uint32"/>
+                <param datatype="uint8" name="role" type="uint8"/>
+                <param datatype="uint32" name="crc_init" type="uint32"/>
+                <param datatype="uint16" name="interval" type="uint16"/>
+                <param datatype="uint16" name="supervision_timeout" type="uint16"/>
+                <param datatype="uint8" name="central_clock_accuracy" type="uint8"/>
+                <param datatype="uint8" name="central_phy" type="uint8"/>
+                <param datatype="uint8" name="peripheral_phy" type="uint8"/>
+                <param datatype="uint8" name="channel_selection_algorithm" type="uint8"/>
+                <param datatype="uint8" name="hop" type="uint8"/>
+                <param datatype="connection_channel_map" name="channel_map" type="byte_array"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="uint16" name="event_counter" type="uint16"/>
+                <param datatype="uint32" name="start_time_us" type="uint32"/>
+            </returns>
+        </command>
+        <command index="23" name="get_remote_address" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+            </returns>
+        </command>
+        <command index="26" name="request_subrate" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="min_subrate" type="uint16"/>
+                <param datatype="uint16" name="max_subrate" type="uint16"/>
+                <param datatype="uint16" name="max_latency" type="uint16"/>
+                <param datatype="uint16" name="continuation_number" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="24" name="get_state" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="state" type="uint8"/>
+            </returns>
+        </command>
+        <command index="5" name="close" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="15" name="forcefully_close" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="opened">
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="role" type="uint8"/>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+                <param datatype="uint8" name="advertiser" type="uint8"/>
+                <param datatype="uint16" name="sync" type="uint16"/>
+            </params>
+        </event>
+        <event index="2" name="parameters">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="interval" type="uint16"/>
+                <param datatype="uint16" name="latency" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint8" name="security_mode" type="uint8"/>
+            </params>
+        </event>
+        <event index="16" name="set_parameters_failed">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+        </event>
+        <event index="4" name="phy_status">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+            </params>
+        </event>
+        <event index="5" name="get_remote_tx_power_completed">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="int8" name="power_level" type="int8"/>
+                <param datatype="uint8" name="flags" type="uint8"/>
+                <param datatype="int8" name="delta" type="int8"/>
+            </params>
+        </event>
+        <event index="6" name="tx_power">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="int8" name="power_level" type="int8"/>
+                <param datatype="uint8" name="flags" type="uint8"/>
+                <param datatype="int8" name="delta" type="int8"/>
+            </params>
+        </event>
+        <event index="7" name="remote_tx_power">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="int8" name="power_level" type="int8"/>
+                <param datatype="uint8" name="flags" type="uint8"/>
+                <param datatype="int8" name="delta" type="int8"/>
+            </params>
+        </event>
+        <event index="8" name="remote_used_features">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8array" name="features" type="uint8array"/>
+            </params>
+        </event>
+        <event index="9" name="data_length">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="tx_data_len" type="uint16"/>
+                <param datatype="uint16" name="tx_time_us" type="uint16"/>
+                <param datatype="uint16" name="rx_data_len" type="uint16"/>
+                <param datatype="uint16" name="rx_time_us" type="uint16"/>
+            </params>
+        </event>
+        <event index="10" name="statistics">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="dbm" name="rssi_min" type="int8"/>
+                <param datatype="dbm" name="rssi_max" type="int8"/>
+                <param datatype="uint32" name="num_total_connection_events" type="uint32"/>
+                <param datatype="uint32" name="num_missed_connection_events" type="uint32"/>
+                <param datatype="uint32" name="num_successful_connection_events" type="uint32"/>
+                <param datatype="uint32" name="num_crc_errors" type="uint32"/>
+            </params>
+        </event>
+        <event index="13" name="request_subrate_failed">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </params>
+        </event>
+        <event index="14" name="subrate_changed">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="subrate_factor" type="uint16"/>
+                <param datatype="uint16" name="latency" type="uint16"/>
+                <param datatype="uint16" name="continuation_number" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+            </params>
+        </event>
+        <event index="1" name="closed">
+            <params>
+                <param datatype="errorcode" name="reason" type="uint16"/>
+                <param datatype="uint8" name="connection" type="uint8"/>
+            </params>
+        </event>
+        <enums name="role">
+            <enum name="role_peripheral" value="0x0"/>
+            <enum name="role_central" value="0x1"/>
+        </enums>
+        <enums name="state">
+            <enum name="state_closed" value="0x0"/>
+            <enum name="state_closing" value="0x1"/>
+            <enum name="state_open" value="0x2"/>
+            <enum name="state_opening" value="0x3"/>
+        </enums>
+        <enums name="security">
+            <enum name="mode1_level1" value="0x0"/>
+            <enum name="mode1_level2" value="0x1"/>
+            <enum name="mode1_level3" value="0x2"/>
+            <enum name="mode1_level4" value="0x3"/>
+        </enums>
+        <enums name="power_reporting_mode">
+            <enum name="power_reporting_disable" value="0x0"/>
+            <enum name="power_reporting_enable" value="0x1"/>
+        </enums>
+        <enums name="tx_power_flag">
+            <enum name="tx_power_flag_none" value="0x0"/>
+            <enum name="tx_power_at_minimum" value="0x1"/>
+            <enum name="tx_power_at_maximum" value="0x2"/>
+        </enums>
+        <defines name="rssi_const">
+            <define name="rssi_unavailable" value="0x7f"/>
+        </defines>
+        <defines name="tx_power_const">
+            <define name="tx_power_unmanaged" value="0x7e"/>
+            <define name="tx_power_unavailable" value="0x7f"/>
+            <define name="tx_power_change_unavailable" value="0x7f"/>
+        </defines>
+    </class>
+    <class index="9" name="gatt">
+        <command index="0" name="set_max_mtu" >
+            <params>
+                <param datatype="uint16" name="max_mtu" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="max_mtu_out" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="discover_primary_services" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="discover_primary_services_by_uuid" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uuid" name="uuid" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="16" name="find_included_services" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="service" name="service" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="discover_characteristics" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="service" name="service" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="discover_characteristics_by_uuid" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="service" name="service" type="uint32"/>
+                <param datatype="uuid" name="uuid" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="6" name="discover_descriptors" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="20" name="discover_characteristic_descriptors" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="start" type="uint16"/>
+                <param datatype="characteristic" name="end" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="set_characteristic_notification" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint8" name="flags" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="13" name="send_characteristic_confirmation" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="7" name="read_characteristic_value" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="18" name="read_characteristic_value_from_offset" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16" name="maxlen" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="23" name="read_multiple_characteristic_values" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint16array" name="characteristic_list" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="24" name="read_variable_length_characteristic_values" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint16array" name="characteristic_list" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="8" name="read_characteristic_value_by_uuid" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="service" name="service" type="uint32"/>
+                <param datatype="uuid" name="uuid" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="25" name="write_characteristic_value" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="26" name="write_characteristic_value_without_response" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="sent_len" type="uint16"/>
+            </returns>
+        </command>
+        <command index="27" name="prepare_characteristic_value_write" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="sent_len" type="uint16"/>
+            </returns>
+        </command>
+        <command index="28" name="prepare_characteristic_value_reliable_write" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="sent_len" type="uint16"/>
+            </returns>
+        </command>
+        <command index="12" name="execute_characteristic_value_write" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="flags" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="14" name="read_descriptor_value" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="descriptor" name="descriptor" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="29" name="write_descriptor_value" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="descriptor" name="descriptor" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="21" name="get_mtu" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="mtu" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="mtu_exchanged">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint16" name="mtu" type="uint16"/>
+            </params>
+        </event>
+        <event index="1" name="service">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="service" name="service" type="uint32"/>
+                <param datatype="uuid" name="uuid" type="uint8array"/>
+            </params>
+        </event>
+        <event index="2" name="characteristic">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint8" name="properties" type="uint8"/>
+                <param datatype="uuid" name="uuid" type="uint8array"/>
+            </params>
+        </event>
+        <event index="3" name="descriptor">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="descriptor" name="descriptor" type="uint16"/>
+                <param datatype="uuid" name="uuid" type="uint8array"/>
+            </params>
+        </event>
+        <event index="7" name="characteristic_value">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="att_opcode" name="att_opcode" type="uint8"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+        </event>
+        <event index="8" name="descriptor_value">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="descriptor" name="descriptor" type="uint16"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+        </event>
+        <event index="6" name="procedure_completed">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </params>
+        </event>
+        <enums name="att_opcode">
+            <enum name="read_by_type_request" value="0x8"/>
+            <enum name="read_by_type_response" value="0x9"/>
+            <enum name="read_request" value="0xa"/>
+            <enum name="read_response" value="0xb"/>
+            <enum name="read_blob_request" value="0xc"/>
+            <enum name="read_blob_response" value="0xd"/>
+            <enum name="read_multiple_request" value="0xe"/>
+            <enum name="read_multiple_response" value="0xf"/>
+            <enum name="write_request" value="0x12"/>
+            <enum name="write_response" value="0x13"/>
+            <enum name="write_command" value="0x52"/>
+            <enum name="prepare_write_request" value="0x16"/>
+            <enum name="prepare_write_response" value="0x17"/>
+            <enum name="execute_write_request" value="0x18"/>
+            <enum name="execute_write_response" value="0x19"/>
+            <enum name="handle_value_notification" value="0x1b"/>
+            <enum name="handle_value_indication" value="0x1d"/>
+        </enums>
+        <enums name="client_config_flag">
+            <enum name="disable" value="0x0"/>
+            <enum name="notification" value="0x1"/>
+            <enum name="indication" value="0x2"/>
+        </enums>
+        <enums name="execute_write_flag">
+            <enum name="cancel" value="0x0"/>
+            <enum name="commit" value="0x1"/>
+        </enums>
+    </class>
+    <class index="70" name="gattdb">
+        <command index="0" name="new_session" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="session" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="add_service" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+                <param datatype="uint8" name="property" type="uint8"/>
+                <param datatype="uuid" name="uuid" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="attribute_handle" name="service" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="remove_service" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="service" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="add_included_service" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="service" type="uint16"/>
+                <param datatype="attribute_handle" name="included_service" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="attribute" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="remove_included_service" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="attribute" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="add_uuid16_characteristic" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="service" type="uint16"/>
+                <param datatype="uint16" name="property" type="uint16"/>
+                <param datatype="uint16" name="security" type="uint16"/>
+                <param datatype="uint8" name="flag" type="uint8"/>
+                <param datatype="uuid_16" name="uuid" type="sl_bt_uuid_16_t"/>
+                <param datatype="uint8" name="value_type" type="uint8"/>
+                <param datatype="uint16" name="maxlen" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="attribute_handle" name="characteristic" type="uint16"/>
+            </returns>
+        </command>
+        <command index="6" name="add_uuid128_characteristic" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="service" type="uint16"/>
+                <param datatype="uint16" name="property" type="uint16"/>
+                <param datatype="uint16" name="security" type="uint16"/>
+                <param datatype="uint8" name="flag" type="uint8"/>
+                <param datatype="uuid_128" name="uuid" type="uuid_128"/>
+                <param datatype="uint8" name="value_type" type="uint8"/>
+                <param datatype="uint16" name="maxlen" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="attribute_handle" name="characteristic" type="uint16"/>
+            </returns>
+        </command>
+        <command index="7" name="remove_characteristic" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="characteristic" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="8" name="add_uuid16_descriptor" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="characteristic" type="uint16"/>
+                <param datatype="uint16" name="property" type="uint16"/>
+                <param datatype="uint16" name="security" type="uint16"/>
+                <param datatype="uuid_16" name="uuid" type="sl_bt_uuid_16_t"/>
+                <param datatype="uint8" name="value_type" type="uint8"/>
+                <param datatype="uint16" name="maxlen" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="attribute_handle" name="descriptor" type="uint16"/>
+            </returns>
+        </command>
+        <command index="9" name="add_uuid128_descriptor" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="characteristic" type="uint16"/>
+                <param datatype="uint16" name="property" type="uint16"/>
+                <param datatype="uint16" name="security" type="uint16"/>
+                <param datatype="uuid_128" name="uuid" type="uuid_128"/>
+                <param datatype="uint8" name="value_type" type="uint8"/>
+                <param datatype="uint16" name="maxlen" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="attribute_handle" name="descriptor" type="uint16"/>
+            </returns>
+        </command>
+        <command index="10" name="remove_descriptor" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="descriptor" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="11" name="start_service" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="service" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="12" name="stop_service" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="service" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="13" name="start_characteristic" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="characteristic" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="14" name="stop_characteristic" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+                <param datatype="attribute_handle" name="characteristic" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="15" name="commit" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="16" name="abort" >
+            <params>
+                <param datatype="uint16" name="session" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="17" name="get_attribute_state" >
+            <params>
+                <param datatype="uint16" name="attribute" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="state" type="uint8"/>
+            </returns>
+        </command>
+        <enums name="service_type">
+            <enum name="primary_service" value="0x0"/>
+            <enum name="secondary_service" value="0x1"/>
+        </enums>
+        <enums name="attribute_category">
+            <enum name="category_service" value="0x1"/>
+            <enum name="category_include" value="0x2"/>
+            <enum name="category_characteristic_declaration" value="0x3"/>
+            <enum name="category_characteristic_value" value="0x4"/>
+            <enum name="category_descriptor" value="0x5"/>
+        </enums>
+        <enums name="value_type">
+            <enum name="fixed_length_value" value="0x1"/>
+            <enum name="variable_length_value" value="0x2"/>
+            <enum name="user_managed_value" value="0x3"/>
+        </enums>
+        <defines name="service_property_flags">
+            <define name="advertised_service" value="0x1"/>
+        </defines>
+        <defines name="security_requirements">
+            <define name="encrypted_read" value="0x1"/>
+            <define name="bonded_read" value="0x2"/>
+            <define name="authenticated_read" value="0x4"/>
+            <define name="encrypted_write" value="0x8"/>
+            <define name="bonded_write" value="0x10"/>
+            <define name="authenticated_write" value="0x20"/>
+            <define name="encrypted_notify" value="0x40"/>
+            <define name="bonded_notify" value="0x80"/>
+            <define name="authenticated_notify" value="0x100"/>
+        </defines>
+        <defines name="flags">
+            <define name="no_auto_cccd" value="0x1"/>
+        </defines>
+        <defines name="characteristic_properties">
+            <define name="characteristic_read" value="0x2"/>
+            <define name="characteristic_write_no_response" value="0x4"/>
+            <define name="characteristic_write" value="0x8"/>
+            <define name="characteristic_notify" value="0x10"/>
+            <define name="characteristic_indicate" value="0x20"/>
+            <define name="characteristic_extended_props" value="0x80"/>
+            <define name="characteristic_reliable_write" value="0x101"/>
+        </defines>
+        <defines name="descriptor_properties">
+            <define name="descriptor_read" value="0x1"/>
+            <define name="descriptor_write" value="0x2"/>
+            <define name="descriptor_local_only" value="0x200"/>
+        </defines>
+        <defines name="attribute_state">
+            <define name="attribute_state_flag_active" value="0x1"/>
+            <define name="attribute_state_flag_started" value="0x2"/>
+            <define name="attribute_state_flag_stopped" value="0x4"/>
+            <define name="attribute_state_flag_added" value="0x8"/>
+            <define name="attribute_state_flag_deleted" value="0x10"/>
+        </defines>
+    </class>
+    <class index="10" name="gatt_server">
+        <command index="10" name="set_max_mtu" >
+            <params>
+                <param datatype="uint16" name="max_mtu" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="max_mtu_out" type="uint16"/>
+            </returns>
+        </command>
+        <command index="11" name="get_mtu" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="mtu" type="uint16"/>
+            </returns>
+        </command>
+        <command index="6" name="find_attribute" >
+            <params>
+                <param datatype="uint16" name="start" type="uint16"/>
+                <param datatype="uint8array" name="type" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="characteristic" name="attribute" type="uint16"/>
+            </returns>
+        </command>
+        <command index="9" name="find_primary_service" >
+            <params>
+                <param datatype="uint16" name="start" type="uint16"/>
+                <param datatype="uint8array" name="uuid" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="start_out" type="uint16"/>
+                <param datatype="uint16" name="end_out" type="uint16"/>
+            </returns>
+        </command>
+        <command index="22" name="read_attribute_value" >
+            <params>
+                <param datatype="characteristic" name="attribute" type="uint16"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </returns>
+        </command>
+        <command index="1" name="read_attribute_type" >
+            <params>
+                <param datatype="characteristic" name="attribute" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8array" name="type" type="uint8array"/>
+            </returns>
+        </command>
+        <command index="5" name="read_attribute_properties" >
+            <params>
+                <param datatype="attribute_handle" name="attribute" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="category" type="uint8"/>
+                <param datatype="uint16" name="security" type="uint16"/>
+                <param datatype="uint16" name="properties" type="uint16"/>
+                <param datatype="uint8" name="value_type" type="uint8"/>
+                <param datatype="uint16" name="len" type="uint16"/>
+                <param datatype="uint16" name="max_writable_len" type="uint16"/>
+            </returns>
+        </command>
+        <command index="23" name="write_attribute_value" >
+            <params>
+                <param datatype="characteristic" name="attribute" type="uint16"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="24" name="send_user_read_response" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="att_errorcode" name="att_errorcode" type="uint8"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="sent_len" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="send_user_write_response" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="att_errorcode" name="att_errorcode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="25" name="send_notification" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="29" name="send_notification_with_options" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint32" name="options" type="uint32"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="26" name="send_indication" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="30" name="send_indication_with_options" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint32" name="options" type="uint32"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="27" name="notify_all" >
+            <params>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="18" name="read_client_configuration" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="client_config_flags" type="uint16"/>
+            </returns>
+        </command>
+        <command index="28" name="send_user_prepare_write_response" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="att_errorcode" name="att_errorcode" type="uint8"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="8" name="set_capabilities" >
+            <params>
+                <param datatype="uint32" name="caps" type="uint32"/>
+                <param datatype="uint32" name="reserved" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="12" name="enable_capabilities" >
+            <params>
+                <param datatype="uint32" name="caps" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="13" name="disable_capabilities" >
+            <params>
+                <param datatype="uint32" name="caps" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="14" name="get_enabled_capabilities" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint32" name="caps" type="uint32"/>
+            </returns>
+        </command>
+        <command index="21" name="read_client_supported_features" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="client_features" type="uint8"/>
+            </returns>
+        </command>
+        <event index="7" name="attribute_value">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="attribute" type="uint16"/>
+                <param datatype="att_opcode" name="att_opcode" type="uint8"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+        </event>
+        <event index="1" name="user_read_request">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="att_opcode" name="att_opcode" type="uint8"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+            </params>
+        </event>
+        <event index="8" name="user_write_request">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="att_opcode" name="att_opcode" type="uint8"/>
+                <param datatype="uint16" name="offset" type="uint16"/>
+                <param datatype="uint16array" name="value" type="uint16array"/>
+            </params>
+        </event>
+        <event index="3" name="characteristic_status">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="characteristic" name="characteristic" type="uint16"/>
+                <param datatype="uint8" name="status_flags" type="uint8"/>
+                <param datatype="uint16" name="client_config_flags" type="uint16"/>
+                <param datatype="descriptor" name="client_config" type="uint16"/>
+            </params>
+        </event>
+        <event index="4" name="execute_write_completed">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </params>
+        </event>
+        <event index="5" name="indication_timeout">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+        </event>
+        <event index="6" name="notification_tx_completed">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="count" type="uint8"/>
+            </params>
+        </event>
+        <enums name="client_configuration">
+            <enum name="disable" value="0x0"/>
+            <enum name="notification" value="0x1"/>
+            <enum name="indication" value="0x2"/>
+            <enum name="notification_and_indication" value="0x3"/>
+        </enums>
+        <enums name="characteristic_status_flag">
+            <enum name="client_config" value="0x1"/>
+            <enum name="confirmation" value="0x2"/>
+        </enums>
+        <defines name="send_option">
+            <define name="send_option_none" value="0x0"/>
+            <define name="send_option_ignore_cccd" value="0x1"/>
+        </defines>
+    </class>
+    <class index="13" name="nvm">
+        <command index="2" name="save" >
+            <params>
+                <param datatype="uint16" name="key" type="uint16"/>
+                <param datatype="uint8array" name="value" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="load" >
+            <params>
+                <param datatype="uint16" name="key" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8array" name="value" type="uint8array"/>
+            </returns>
+        </command>
+        <command index="4" name="erase" >
+            <params>
+                <param datatype="uint16" name="key" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="erase_all" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <defines name="key_range">
+            <define name="key_range_user_min" value="0x4000"/>
+            <define name="key_range_user_max" value="0x5fff"/>
+        </defines>
+    </class>
+    <class index="14" name="test">
+        <command index="3" name="dtm_tx_v4" >
+            <params>
+                <param datatype="uint8" name="packet_type" type="uint8"/>
+                <param datatype="uint8" name="length" type="uint8"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="int8" name="power_level" type="int8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="dtm_tx_cw" >
+            <params>
+                <param datatype="uint8" name="packet_type" type="uint8"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="int16" name="power_level" type="int16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="dtm_rx" >
+            <params>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="dtm_end" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="dtm_completed">
+            <params>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="number_of_packets" type="uint16"/>
+            </params>
+        </event>
+        <enums name="packet_type">
+            <enum name="pkt_prbs9" value="0x0"/>
+            <enum name="pkt_11110000" value="0x1"/>
+            <enum name="pkt_10101010" value="0x2"/>
+            <enum name="pkt_11111111" value="0x4"/>
+            <enum name="pkt_00000000" value="0x5"/>
+            <enum name="pkt_00001111" value="0x6"/>
+            <enum name="pkt_01010101" value="0x7"/>
+            <enum name="pkt_pn9" value="0xfd"/>
+            <enum name="pkt_carrier" value="0xfe"/>
+        </enums>
+        <enums name="phy">
+            <enum name="phy_1m" value="0x1"/>
+            <enum name="phy_2m" value="0x2"/>
+            <enum name="phy_125k" value="0x3"/>
+            <enum name="phy_500k" value="0x4"/>
+        </enums>
+    </class>
+    <class index="15" name="sm">
+        <command index="1" name="configure" >
+            <params>
+                <param datatype="uint8" name="flags" type="uint8"/>
+                <param datatype="uint8" name="io_capabilities" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="20" name="set_minimum_key_size" >
+            <params>
+                <param datatype="uint8" name="minimum_key_size" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="15" name="set_debug_mode" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="store_bonding_configuration" >
+            <params>
+                <param datatype="uint8" name="max_bonding_count" type="uint8"/>
+                <param datatype="uint8" name="policy_flags" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="0" name="set_bondable_mode" >
+            <params>
+                <param datatype="uint8" name="bondable" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="16" name="set_passkey" >
+            <params>
+                <param datatype="int32" name="passkey" type="int32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="increase_security" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="8" name="enter_passkey" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="int32" name="passkey" type="int32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="9" name="passkey_confirm" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="confirm" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="14" name="bonding_confirm" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="confirm" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="6" name="delete_bonding" >
+            <params>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="7" name="delete_bondings" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="21" name="get_bonding_handles" >
+            <params>
+                <param datatype="uint32" name="reserved" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint32" name="num_bondings" type="uint32"/>
+                <param datatype="uint8array" name="bondings" type="uint8array"/>
+            </returns>
+        </command>
+        <command index="22" name="get_bonding_details" >
+            <params>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="security_mode" type="uint8"/>
+                <param datatype="uint8" name="key_size" type="uint8"/>
+            </returns>
+        </command>
+        <command index="23" name="find_bonding_by_address" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+                <param datatype="uint8" name="security_mode" type="uint8"/>
+                <param datatype="uint8" name="key_size" type="uint8"/>
+            </returns>
+        </command>
+        <command index="29" name="resolve_rpa" >
+            <params>
+                <param datatype="bd_addr" name="rpa" type="bd_addr"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+            </returns>
+        </command>
+        <command index="24" name="set_bonding_key" >
+            <params>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+                <param datatype="uint8" name="key_type" type="uint8"/>
+                <param datatype="aes_key_128" name="key" type="aes_key_128"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="25" name="set_legacy_oob" >
+            <params>
+                <param datatype="uint8" name="enable" type="uint8"/>
+                <param datatype="aes_key_128" name="oob_data" type="aes_key_128"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="26" name="set_oob" >
+            <params>
+                <param datatype="uint8" name="enable" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="aes_key_128" name="random" type="aes_key_128"/>
+                <param datatype="aes_key_128" name="confirm" type="aes_key_128"/>
+            </returns>
+        </command>
+        <command index="27" name="set_remote_oob" >
+            <params>
+                <param datatype="uint8" name="enable" type="uint8"/>
+                <param datatype="aes_key_128" name="random" type="aes_key_128"/>
+                <param datatype="aes_key_128" name="confirm" type="aes_key_128"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="passkey_display">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint32" name="passkey" type="uint32"/>
+            </params>
+        </event>
+        <event index="1" name="passkey_request">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+        </event>
+        <event index="2" name="confirm_passkey">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint32" name="passkey" type="uint32"/>
+            </params>
+        </event>
+        <event index="3" name="bonded">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="bonding" type="uint8"/>
+                <param datatype="uint8" name="security_mode" type="uint8"/>
+            </params>
+        </event>
+        <event index="4" name="bonding_failed">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="errorcode" name="reason" type="uint16"/>
+            </params>
+        </event>
+        <event index="9" name="confirm_bonding">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="bonding_handle" type="uint8"/>
+            </params>
+        </event>
+        <enums name="bonding_key">
+            <enum name="bonding_key_remote_ltk" value="0x1"/>
+            <enum name="bonding_key_local_ltk" value="0x2"/>
+            <enum name="bonding_key_irk" value="0x3"/>
+        </enums>
+        <enums name="bonding_data">
+            <enum name="bonding_data_remote_address" value="0x0"/>
+            <enum name="bonding_data_remote_ltk" value="0x1"/>
+            <enum name="bonding_data_local_ltk" value="0x2"/>
+            <enum name="bonding_data_remote_master_inf" value="0x3"/>
+            <enum name="bonding_data_local_master_inf" value="0x4"/>
+            <enum name="bonding_data_irk" value="0x5"/>
+            <enum name="bonding_data_meta" value="0x6"/>
+            <enum name="bonding_data_gatt_client_config" value="0x7"/>
+            <enum name="bonding_data_gatt_client_features" value="0x8"/>
+            <enum name="bonding_data_gatt_db_hash" value="0x9"/>
+        </enums>
+        <enums name="io_capability">
+            <enum name="io_capability_displayonly" value="0x0"/>
+            <enum name="io_capability_displayyesno" value="0x1"/>
+            <enum name="io_capability_keyboardonly" value="0x2"/>
+            <enum name="io_capability_noinputnooutput" value="0x3"/>
+            <enum name="io_capability_keyboarddisplay" value="0x4"/>
+        </enums>
+        <defines name="configuration">
+            <define name="configuration_mitm_required" value="0x1"/>
+            <define name="configuration_bonding_required" value="0x2"/>
+            <define name="configuration_sc_only" value="0x4"/>
+            <define name="configuration_bonding_request_required" value="0x8"/>
+            <define name="configuration_connections_from_bonded_devices_only" value="0x10"/>
+            <define name="configuration_prefer_mitm" value="0x20"/>
+            <define name="configuration_oob_from_both_devices_required" value="0x40"/>
+            <define name="configuration_reject_debug_keys" value="0x80"/>
+        </defines>
+    </class>
+    <class index="92" name="external_bondingdb">
+        <command index="0" name="set_data" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="data_request">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+            </params>
+        </event>
+        <event index="1" name="data">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="type" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+        <event index="2" name="data_ready">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+        </event>
+        <enums name="data">
+            <enum name="data_remote_address" value="0x0"/>
+            <enum name="data_remote_address_type" value="0x1"/>
+            <enum name="data_remote_ltk" value="0x2"/>
+            <enum name="data_local_ltk" value="0x3"/>
+            <enum name="data_remote_central_inf" value="0x4"/>
+            <enum name="data_local_central_inf" value="0x5"/>
+            <enum name="data_irk" value="0x6"/>
+            <enum name="data_meta" value="0x7"/>
+            <enum name="data_gatt_client_config" value="0x8"/>
+            <enum name="data_gatt_client_features" value="0x9"/>
+            <enum name="data_gatt_db_hash" value="0xa"/>
+        </enums>
+    </class>
+    <class index="93" name="resolving_list">
+        <command index="0" name="add_device_by_bonding" >
+            <params>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+                <param datatype="uint8" name="privacy_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="add_device_by_address" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="aes_key_128" name="key" type="aes_key_128"/>
+                <param datatype="uint8" name="privacy_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="remove_device_by_bonding" >
+            <params>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="remove_device_by_address" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="remove_all_devices" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <enums name="privacy_mode">
+            <enum name="privacy_mode_network" value="0x0"/>
+            <enum name="privacy_mode_device" value="0x1"/>
+        </enums>
+    </class>
+    <class index="94" name="accept_list">
+        <command index="0" name="add_device_by_bonding" >
+            <params>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="add_device_by_address" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="remove_device_by_bonding" >
+            <params>
+                <param datatype="uint32" name="bonding" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="remove_device_by_address" >
+            <params>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="remove_all_devices" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+    </class>
+    <class index="32" name="coex">
+        <command index="0" name="set_options" >
+            <params>
+                <param datatype="uint32" name="mask" type="uint32"/>
+                <param datatype="uint32" name="options" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="set_parameters" >
+            <params>
+                <param datatype="uint8" name="priority" type="uint8"/>
+                <param datatype="uint8" name="request" type="uint8"/>
+                <param datatype="uint8" name="pwm_period" type="uint8"/>
+                <param datatype="uint8" name="pwm_dutycycle" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="set_directional_priority_pulse" >
+            <params>
+                <param datatype="uint8" name="pulse" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="get_parameters" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="priority" type="uint8"/>
+                <param datatype="uint8" name="request" type="uint8"/>
+                <param datatype="uint8" name="pwm_period" type="uint8"/>
+                <param datatype="uint8" name="pwm_dutycycle" type="uint8"/>
+            </returns>
+        </command>
+        <command index="1" name="get_counters" >
+            <params>
+                <param datatype="uint8" name="reset" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8array" name="counters" type="uint8array"/>
+            </returns>
+        </command>
+        <enums name="option">
+            <enum name="option_enable" value="0x100"/>
+            <enum name="option_tx_abort" value="0x400"/>
+            <enum name="option_high_priority" value="0x800"/>
+        </enums>
+    </class>
+    <class index="89" name="cs">
+        <command index="0" name="security_enable" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="set_default_settings" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="initiator_status" type="uint8"/>
+                <param datatype="uint8" name="reflector_status" type="uint8"/>
+                <param datatype="uint8" name="antenna_identifier" type="uint8"/>
+                <param datatype="int8" name="max_tx_power" type="int8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="create_config" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+                <param datatype="uint8" name="create_context" type="uint8"/>
+                <param datatype="uint8" name="main_mode_type" type="uint8"/>
+                <param datatype="uint8" name="sub_mode_type" type="uint8"/>
+                <param datatype="uint8" name="min_main_mode_steps" type="uint8"/>
+                <param datatype="uint8" name="max_main_mode_steps" type="uint8"/>
+                <param datatype="uint8" name="main_mode_repetition" type="uint8"/>
+                <param datatype="uint8" name="mode_calibration_steps" type="uint8"/>
+                <param datatype="uint8" name="role" type="uint8"/>
+                <param datatype="uint8" name="rtt_type" type="uint8"/>
+                <param datatype="uint8" name="cs_sync_phy" type="uint8"/>
+                <param datatype="cs_channel_map" name="channel_map" type="byte_array"/>
+                <param datatype="uint8" name="channel_map_repetition" type="uint8"/>
+                <param datatype="uint8" name="channel_selection_type" type="uint8"/>
+                <param datatype="uint8" name="ch3c_shape" type="uint8"/>
+                <param datatype="uint8" name="ch3c_jump" type="uint8"/>
+                <param datatype="uint8" name="reserved" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="remove_config" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="set_channel_classification" >
+            <params>
+                <param datatype="cs_channel_map" name="channel_map" type="byte_array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="set_procedure_parameters" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+                <param datatype="uint16" name="max_procedure_len" type="uint16"/>
+                <param datatype="uint16" name="min_procedure_interval" type="uint16"/>
+                <param datatype="uint16" name="max_procedure_interval" type="uint16"/>
+                <param datatype="uint16" name="max_procedure_count" type="uint16"/>
+                <param datatype="uint32" name="min_subevent_len" type="uint32"/>
+                <param datatype="uint32" name="max_subevent_len" type="uint32"/>
+                <param datatype="uint8" name="tone_antenna_config_selection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="int8" name="tx_pwr_delta" type="int8"/>
+                <param datatype="uint8" name="preferred_peer_antenna" type="uint8"/>
+                <param datatype="uint8" name="snr_control_initiator" type="uint8"/>
+                <param datatype="uint8" name="snr_control_reflector" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="6" name="procedure_enable" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="enable" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="7" name="set_antenna_configuration" >
+            <params>
+                <param datatype="uint8array" name="antenna_element_offset" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="8" name="read_local_supported_capabilities" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="num_config" type="uint8"/>
+                <param datatype="uint16" name="max_consecutive_procedures" type="uint16"/>
+                <param datatype="uint8" name="num_antennas" type="uint8"/>
+                <param datatype="uint8" name="max_antenna_paths" type="uint8"/>
+                <param datatype="uint8" name="roles" type="uint8"/>
+                <param datatype="uint8" name="modes" type="uint8"/>
+                <param datatype="uint8" name="rtt_capability" type="uint8"/>
+                <param datatype="uint8" name="rtt_aa_only" type="uint8"/>
+                <param datatype="uint8" name="rtt_sounding" type="uint8"/>
+                <param datatype="uint8" name="rtt_random_payload" type="uint8"/>
+                <param datatype="uint8" name="cs_sync_phys" type="uint8"/>
+                <param datatype="uint16" name="subfeatures" type="uint16"/>
+                <param datatype="uint16" name="t_ip1_times" type="uint16"/>
+                <param datatype="uint16" name="t_ip2_times" type="uint16"/>
+                <param datatype="uint16" name="t_fcs_times" type="uint16"/>
+                <param datatype="uint16" name="t_pm_times" type="uint16"/>
+                <param datatype="uint8" name="t_sw_times" type="uint8"/>
+                <param datatype="uint8" name="tx_snr_capability" type="uint8"/>
+            </returns>
+        </command>
+        <command index="9" name="read_remote_supported_capabilities" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="security_enable_complete">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+        </event>
+        <event index="1" name="config_complete">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint8" name="config_state" type="uint8"/>
+                <param datatype="uint8" name="main_mode_type" type="uint8"/>
+                <param datatype="uint8" name="sub_mode_type" type="uint8"/>
+                <param datatype="uint8" name="min_main_mode_steps" type="uint8"/>
+                <param datatype="uint8" name="max_main_mode_steps" type="uint8"/>
+                <param datatype="uint8" name="main_mode_repetition" type="uint8"/>
+                <param datatype="uint8" name="mode_calibration_steps" type="uint8"/>
+                <param datatype="uint8" name="role" type="uint8"/>
+                <param datatype="uint8" name="rtt_type" type="uint8"/>
+                <param datatype="uint8" name="cs_sync_phy" type="uint8"/>
+                <param datatype="cs_channel_map" name="channel_map" type="byte_array"/>
+                <param datatype="uint8" name="channel_map_repetition" type="uint8"/>
+                <param datatype="uint8" name="channel_selection_type" type="uint8"/>
+                <param datatype="uint8" name="ch3c_shape" type="uint8"/>
+                <param datatype="uint8" name="ch3c_jump" type="uint8"/>
+                <param datatype="uint8" name="reserved" type="uint8"/>
+                <param datatype="uint8" name="t_ip1_time" type="uint8"/>
+                <param datatype="uint8" name="t_ip2_time" type="uint8"/>
+                <param datatype="uint8" name="t_fcs_time" type="uint8"/>
+                <param datatype="uint8" name="t_pm_time" type="uint8"/>
+            </params>
+        </event>
+        <event index="2" name="procedure_enable_complete">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint8" name="state" type="uint8"/>
+                <param datatype="uint8" name="antenna_config" type="uint8"/>
+                <param datatype="int8" name="tx_power" type="int8"/>
+                <param datatype="uint32" name="subevent_len" type="uint32"/>
+                <param datatype="uint8" name="subevents_per_event" type="uint8"/>
+                <param datatype="uint16" name="subevent_interval" type="uint16"/>
+                <param datatype="uint16" name="event_interval" type="uint16"/>
+                <param datatype="uint16" name="procedure_interval" type="uint16"/>
+                <param datatype="uint16" name="procedure_count" type="uint16"/>
+                <param datatype="uint16" name="max_procedure_len" type="uint16"/>
+            </params>
+        </event>
+        <event index="3" name="result">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+                <param datatype="uint16" name="start_acl_conn_event" type="uint16"/>
+                <param datatype="uint16" name="procedure_counter" type="uint16"/>
+                <param datatype="int16" name="frequency_compensation" type="int16"/>
+                <param datatype="int8" name="reference_power_level" type="int8"/>
+                <param datatype="uint8" name="procedure_done_status" type="uint8"/>
+                <param datatype="uint8" name="subevent_done_status" type="uint8"/>
+                <param datatype="uint8" name="abort_reason" type="uint8"/>
+                <param datatype="uint8" name="num_antenna_paths" type="uint8"/>
+                <param datatype="uint8" name="num_steps" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+        <event index="5" name="result_continue">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="config_id" type="uint8"/>
+                <param datatype="uint8" name="procedure_done_status" type="uint8"/>
+                <param datatype="uint8" name="subevent_done_status" type="uint8"/>
+                <param datatype="uint8" name="abort_reason" type="uint8"/>
+                <param datatype="uint8" name="num_antenna_paths" type="uint8"/>
+                <param datatype="uint8" name="num_steps" type="uint8"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+        <event index="4" name="read_remote_supported_capabilities_complete">
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint8" name="num_config" type="uint8"/>
+                <param datatype="uint16" name="max_consecutive_procedures" type="uint16"/>
+                <param datatype="uint8" name="num_antennas" type="uint8"/>
+                <param datatype="uint8" name="max_antenna_paths" type="uint8"/>
+                <param datatype="uint8" name="roles" type="uint8"/>
+                <param datatype="uint8" name="modes" type="uint8"/>
+                <param datatype="uint8" name="rtt_capability" type="uint8"/>
+                <param datatype="uint8" name="rtt_aa_only" type="uint8"/>
+                <param datatype="uint8" name="rtt_sounding" type="uint8"/>
+                <param datatype="uint8" name="rtt_random_payload" type="uint8"/>
+                <param datatype="uint8" name="cs_sync_phys" type="uint8"/>
+                <param datatype="uint16" name="subfeatures" type="uint16"/>
+                <param datatype="uint16" name="t_ip1_times" type="uint16"/>
+                <param datatype="uint16" name="t_ip2_times" type="uint16"/>
+                <param datatype="uint16" name="t_fcs_times" type="uint16"/>
+                <param datatype="uint16" name="t_pm_times" type="uint16"/>
+                <param datatype="uint8" name="t_sw_times" type="uint8"/>
+                <param datatype="uint8" name="tx_snr_capability" type="uint8"/>
+            </params>
+        </event>
+        <enums name="role">
+            <enum name="role_initiator" value="0x0"/>
+            <enum name="role_reflector" value="0x1"/>
+        </enums>
+        <enums name="role_status">
+            <enum name="role_status_disable" value="0x0"/>
+            <enum name="role_status_enable" value="0x1"/>
+        </enums>
+        <enums name="procedure_state">
+            <enum name="procedure_state_disabled" value="0x0"/>
+            <enum name="procedure_state_enabled" value="0x1"/>
+        </enums>
+        <enums name="mode">
+            <enum name="mode_rtt" value="0x1"/>
+            <enum name="mode_pbr" value="0x2"/>
+            <enum name="submode_disabled" value="0xff"/>
+        </enums>
+        <enums name="rtt_type">
+            <enum name="rtt_type_aa_only" value="0x0"/>
+            <enum name="rtt_type_fractional_32_bit_sounding" value="0x1"/>
+            <enum name="rtt_type_fractional_96_bit_sounding" value="0x2"/>
+            <enum name="rtt_type_fractional_32_bit_random" value="0x3"/>
+            <enum name="rtt_type_fractional_64_bit_random" value="0x4"/>
+            <enum name="rtt_type_fractional_96_bit_random" value="0x5"/>
+            <enum name="rtt_type_fractional_128_bit_random" value="0x6"/>
+        </enums>
+        <enums name="channel_selection_algorithm">
+            <enum name="channel_selection_algorithm_3b" value="0x0"/>
+            <enum name="channel_selection_algorithm_3c" value="0x1"/>
+            <enum name="channel_selection_algorithm_user_shape_interleaved" value="0x2"/>
+        </enums>
+        <enums name="ch3c_shape">
+            <enum name="ch3c_shape_hat" value="0x0"/>
+            <enum name="chc3_shape_interleaved" value="0x1"/>
+        </enums>
+        <enums name="done_status">
+            <enum name="done_status_complete" value="0x0"/>
+            <enum name="done_status_partial_results_continue" value="0x1"/>
+            <enum name="done_status_aborted" value="0xf"/>
+        </enums>
+        <enums name="config_state">
+            <enum name="config_state_removed" value="0x0"/>
+            <enum name="config_state_created" value="0x1"/>
+        </enums>
+        <enums name="snr_control_adjustment">
+            <enum name="snr_control_adjustment_not_applied" value="0xff"/>
+        </enums>
+    </class>
+    <class index="90" name="cs_test">
+        <command index="0" name="start" >
+            <params>
+                <param datatype="uint8" name="main_mode_type" type="uint8"/>
+                <param datatype="uint8" name="sub_mode_type" type="uint8"/>
+                <param datatype="uint8" name="main_mode_repetition" type="uint8"/>
+                <param datatype="uint8" name="mode_calibration_steps" type="uint8"/>
+                <param datatype="uint8" name="role" type="uint8"/>
+                <param datatype="uint8" name="rtt_type" type="uint8"/>
+                <param datatype="uint8" name="cs_sync_phy" type="uint8"/>
+                <param datatype="uint8" name="antenna_selection" type="uint8"/>
+                <param datatype="cs_subevent_length" name="subevent_len" type="byte_array"/>
+                <param datatype="uint16" name="subevent_interval" type="uint16"/>
+                <param datatype="uint8" name="max_num_subevents" type="uint8"/>
+                <param datatype="int8" name="tx_power" type="int8"/>
+                <param datatype="uint8" name="t_ip1_time" type="uint8"/>
+                <param datatype="uint8" name="t_ip2_time" type="uint8"/>
+                <param datatype="uint8" name="t_fcs_time" type="uint8"/>
+                <param datatype="uint8" name="t_pm_time" type="uint8"/>
+                <param datatype="uint8" name="t_sw_time" type="uint8"/>
+                <param datatype="uint8" name="tone_antenna_config" type="uint8"/>
+                <param datatype="uint8" name="reserved" type="uint8"/>
+                <param datatype="uint8" name="snr_control_initiator" type="uint8"/>
+                <param datatype="uint8" name="snr_control_reflector" type="uint8"/>
+                <param datatype="uint16" name="drbg_nonce" type="uint16"/>
+                <param datatype="uint8" name="channel_map_repetition" type="uint8"/>
+                <param datatype="uint16" name="override_config" type="uint16"/>
+                <param datatype="uint8array" name="override_parameters" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="end" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="end_completed">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+            </params>
+        </event>
+        <enums name="tone_extension">
+            <enum name="tone_extension_both_without" value="0x0"/>
+            <enum name="tone_extension_reflector_without" value="0x1"/>
+            <enum name="tone_extension_initiator_without" value="0x2"/>
+            <enum name="tone_extension_both_with" value="0x3"/>
+            <enum name="tone_extension_round_robin" value="0x4"/>
+        </enums>
+        <enums name="sounding_sequence_marker">
+            <enum name="sounding_sequence_marker_1" value="0x0"/>
+            <enum name="sounding_sequence_marker_2" value="0x1"/>
+            <enum name="sounding_sequence_marker_round_robin" value="0x2"/>
+        </enums>
+    </class>
+    <class index="67" name="l2cap">
+        <command index="1" name="open_le_channel" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="spsm" type="uint16"/>
+                <param datatype="uint16" name="max_sdu" type="uint16"/>
+                <param datatype="uint16" name="max_pdu" type="uint16"/>
+                <param datatype="uint16" name="credit" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="send_le_channel_open_response" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="uint16" name="max_sdu" type="uint16"/>
+                <param datatype="uint16" name="max_pdu" type="uint16"/>
+                <param datatype="uint16" name="credit" type="uint16"/>
+                <param datatype="uint16" name="errorcode" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="channel_send_data" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="channel_send_credit" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="uint16" name="credit" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="close_channel" >
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="1" name="le_channel_open_request">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="spsm" type="uint16"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="uint16" name="max_sdu" type="uint16"/>
+                <param datatype="uint16" name="max_pdu" type="uint16"/>
+                <param datatype="uint16" name="credit" type="uint16"/>
+                <param datatype="uint16" name="remote_cid" type="uint16"/>
+            </params>
+        </event>
+        <event index="2" name="le_channel_open_response">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="uint16" name="max_sdu" type="uint16"/>
+                <param datatype="uint16" name="max_pdu" type="uint16"/>
+                <param datatype="uint16" name="credit" type="uint16"/>
+                <param datatype="uint16" name="errorcode" type="uint16"/>
+                <param datatype="uint16" name="remote_cid" type="uint16"/>
+            </params>
+        </event>
+        <event index="3" name="channel_data">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+        </event>
+        <event index="4" name="channel_credit">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="uint16" name="credit" type="uint16"/>
+            </params>
+        </event>
+        <event index="5" name="channel_closed">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+                <param datatype="errorcode" name="reason" type="uint16"/>
+            </params>
+        </event>
+        <event index="6" name="command_rejected">
+            <params>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="code" type="uint8"/>
+                <param datatype="uint16" name="reason" type="uint16"/>
+                <param datatype="uint16" name="cid" type="uint16"/>
+            </params>
+        </event>
+        <enums name="connection_result">
+            <enum name="connection_result_successful" value="0x0"/>
+            <enum name="connection_result_spsm_not_supported" value="0x2"/>
+            <enum name="connection_result_no_resources_available" value="0x4"/>
+            <enum name="connection_result_insufficient_authentication" value="0x5"/>
+            <enum name="connection_result_insufficient_authorization" value="0x6"/>
+            <enum name="connection_result_encryption_key_size_too_short" value="0x7"/>
+            <enum name="connection_result_insufficient_encryption" value="0x8"/>
+            <enum name="connection_result_invalid_source_cid" value="0x9"/>
+            <enum name="connection_result_source_cid_already_allocated" value="0xa"/>
+            <enum name="connection_result_unacceptable_parameters" value="0xb"/>
+        </enums>
+        <enums name="command_reject_reason">
+            <enum name="command_not_understood" value="0x0"/>
+            <enum name="signaling_mtu_exceeded" value="0x1"/>
+            <enum name="invalid_cid_request" value="0x2"/>
+        </enums>
+        <enums name="command_code">
+            <enum name="disconnection_request" value="0x6"/>
+            <enum name="le_connection_request" value="0x14"/>
+            <enum name="flow_control_credit" value="0x16"/>
+        </enums>
+    </class>
+    <class index="68" name="cte_transmitter">
+        <command index="4" name="set_dtm_parameters" >
+            <params>
+                <param datatype="uint8" name="cte_length" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="5" name="clear_dtm_parameters" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="0" name="enable_connection_cte" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="cte_types" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="disable_connection_cte" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="enable_connectionless_cte" >
+            <params>
+                <param datatype="uint8" name="handle" type="uint8"/>
+                <param datatype="uint8" name="cte_length" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="cte_count" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="disable_connectionless_cte" >
+            <params>
+                <param datatype="uint8" name="handle" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="6" name="enable_silabs_cte" >
+            <params>
+                <param datatype="uint8" name="handle" type="uint8"/>
+                <param datatype="uint8" name="cte_length" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="cte_count" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="7" name="disable_silabs_cte" >
+            <params>
+                <param datatype="uint8" name="handle" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+    </class>
+    <class index="69" name="cte_receiver">
+        <command index="5" name="set_dtm_parameters" >
+            <params>
+                <param datatype="uint8" name="cte_length" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="6" name="clear_dtm_parameters" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="9" name="set_sync_cte_type" >
+            <params>
+                <param datatype="uint8" name="sync_cte_type" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="10" name="set_default_sync_receive_parameters" >
+            <params>
+                <param datatype="uint8" name="mode" type="uint8"/>
+                <param datatype="uint16" name="skip" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint8" name="sync_cte_type" type="uint8"/>
+                <param datatype="uint8" name="reporting_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="11" name="set_sync_receive_parameters" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint8" name="mode" type="uint8"/>
+                <param datatype="uint16" name="skip" type="uint16"/>
+                <param datatype="uint16" name="timeout" type="uint16"/>
+                <param datatype="uint8" name="sync_cte_type" type="uint8"/>
+                <param datatype="uint8" name="reporting_mode" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="0" name="configure" >
+            <params>
+                <param datatype="uint8" name="flags" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="1" name="enable_connection_cte" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+                <param datatype="uint16" name="interval" type="uint16"/>
+                <param datatype="uint8" name="cte_length" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="disable_connection_cte" >
+            <params>
+                <param datatype="connection" name="connection" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="3" name="enable_connectionless_cte" >
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint8" name="cte_count" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="4" name="disable_connectionless_cte" >
+            <params>
+                <param datatype="uint16" name="sync" type="uint16"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="7" name="enable_silabs_cte" >
+            <params>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint8" name="cte_count" type="uint8"/>
+                <param datatype="uint8array" name="switching_pattern" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="8" name="disable_silabs_cte" >
+            <params/>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="2" name="dtm_iq_report">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="rssi_antenna_id" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint16" name="event_counter" type="uint16"/>
+                <param datatype="uint8array" name="samples" type="uint8array"/>
+            </params>
+        </event>
+        <event index="0" name="connection_iq_report">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint8" name="connection" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="rssi_antenna_id" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint16" name="event_counter" type="uint16"/>
+                <param datatype="uint8array" name="samples" type="uint8array"/>
+            </params>
+        </event>
+        <event index="1" name="connectionless_iq_report">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="uint16" name="sync" type="uint16"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="rssi_antenna_id" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint16" name="event_counter" type="uint16"/>
+                <param datatype="uint8array" name="samples" type="uint8array"/>
+            </params>
+        </event>
+        <event index="3" name="silabs_iq_report">
+            <params>
+                <param datatype="errorcode" name="status" type="uint16"/>
+                <param datatype="bd_addr" name="address" type="bd_addr"/>
+                <param datatype="uint8" name="address_type" type="uint8"/>
+                <param datatype="uint8" name="phy" type="uint8"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="dbm" name="rssi" type="int8"/>
+                <param datatype="uint8" name="rssi_antenna_id" type="uint8"/>
+                <param datatype="uint8" name="cte_type" type="uint8"/>
+                <param datatype="uint8" name="slot_durations" type="uint8"/>
+                <param datatype="uint16" name="packet_counter" type="uint16"/>
+                <param datatype="uint8array" name="samples" type="uint8array"/>
+            </params>
+        </event>
+        <defines name="sync_cte_type">
+            <define name="do_not_sync_to_aoa" value="0x1"/>
+            <define name="do_not_sync_to_aod_1_us" value="0x2"/>
+            <define name="do_not_sync_to_aod_2_us" value="0x4"/>
+            <define name="sync_to_cte_only" value="0x10"/>
+        </defines>
+    </class>
+    <class index="72" name="connection_analyzer">
+        <command index="0" name="start" >
+            <params>
+                <param datatype="uint32" name="access_address" type="uint32"/>
+                <param datatype="uint32" name="crc_init" type="uint32"/>
+                <param datatype="uint16" name="interval" type="uint16"/>
+                <param datatype="uint16" name="supervision_timeout" type="uint16"/>
+                <param datatype="uint8" name="central_clock_accuracy" type="uint8"/>
+                <param datatype="uint8" name="central_phy" type="uint8"/>
+                <param datatype="uint8" name="peripheral_phy" type="uint8"/>
+                <param datatype="uint8" name="channel_selection_algorithm" type="uint8"/>
+                <param datatype="uint8" name="hop" type="uint8"/>
+                <param datatype="connection_channel_map" name="channel_map" type="byte_array"/>
+                <param datatype="uint8" name="channel" type="uint8"/>
+                <param datatype="uint16" name="event_counter" type="uint16"/>
+                <param datatype="int32" name="start_time_us" type="int32"/>
+                <param datatype="uint32" name="flags" type="uint32"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8" name="analyzer" type="uint8"/>
+            </returns>
+        </command>
+        <command index="1" name="stop" >
+            <params>
+                <param datatype="uint8" name="analyzer" type="uint8"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <event index="0" name="report">
+            <params>
+                <param datatype="uint8" name="analyzer" type="uint8"/>
+                <param datatype="int8" name="central_rssi" type="int8"/>
+                <param datatype="int8" name="peripheral_rssi" type="int8"/>
+            </params>
+        </event>
+        <event index="1" name="completed">
+            <params>
+                <param datatype="uint8" name="analyzer" type="uint8"/>
+                <param datatype="errorcode" name="reason" type="uint16"/>
+            </params>
+        </event>
+        <defines name="flags">
+            <define name="relative_time" value="0x1"/>
+        </defines>
+    </class>
+    <class index="255" name="user">
+        <command index="0" name="message_to_target" >
+            <params>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8array" name="response" type="uint8array"/>
+            </returns>
+        </command>
+        <command index="1" name="manage_event_filter" >
+            <params>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+            </returns>
+        </command>
+        <command index="2" name="reset_to_dfu" no_return="true">
+            <params/>
+        </command>
+        <command index="3" name="cs_service_message_to_target" >
+            <params>
+                <param datatype="uint8array" name="data" type="uint8array"/>
+            </params>
+            <returns>
+                <param datatype="errorcode" name="result" type="uint16"/>
+                <param datatype="uint8array" name="response" type="uint8array"/>
+            </returns>
+        </command>
+        <event index="0" name="message_to_host">
+            <params>
+                <param datatype="uint8array" name="message" type="uint8array"/>
+            </params>
+        </event>
+        <event index="1" name="cs_service_message_to_host">
+            <params>
+                <param datatype="uint8array" name="message" type="uint8array"/>
+            </params>
+        </event>
+    </class>
+</api>

--- a/tests/platforms/SiLabs/common/stub_util.resc
+++ b/tests/platforms/SiLabs/common/stub_util.resc
@@ -1,0 +1,23 @@
+python
+"""
+# List of functions to be stubbed out
+stub_list = []
+
+def skip_function_hook(cpu, addr):
+    cpu.PC = cpu.LR
+
+def sl_add_stub_hook(func_name):
+    sysbus = self.Machine["sysbus"]
+    cpu = self.Machine["sysbus.cpu"]
+    # TryGetAllSymbolAddresses returns a tuple (true/false if there are any symbols and the list of symbols)
+    addresses = sysbus.TryGetAllSymbolAddresses(func_name, cpu)[1]
+    for addr in addresses:
+        cpu.AddHook(addr, skip_function_hook)
+
+def sl_add_stub(stub):
+    stub_list.append(stub)
+
+def sl_add_hooks():
+    for func in stub_list:
+        sl_add_stub_hook(func)
+"""

--- a/tests/platforms/SiLabs/common/test_lib.py
+++ b/tests/platforms/SiLabs/common/test_lib.py
@@ -1,0 +1,350 @@
+from pyrenode3.wrappers import Analyzer, Emulation, Monitor, TerminalTester
+from Antmicro.Renode.Time import TimeInterval
+from Antmicro.Renode.Peripherals.Wireless import IEEE802_15_4Medium
+from Antmicro.Renode.Peripherals.CPU import ICpuSupportingGdb
+import System
+import sys
+import argparse
+import os
+
+DEFAULT_QUANTUM_TIME = 0.000020
+DEFAULT_TESTER_TIMEOUT = 10
+DEFAULT_DEBUG_PRINT = False
+DEFAULT_LOG_LEVEL = 1
+
+_machine_name_to_machine_mapping = {}
+_tester_to_machine_mapping = {}
+
+def parse_arguments():
+    """
+    Parses command-line arguments for the Silicon Labs pyrenode3-based testing library.
+
+    Returns:
+        tuple: A tuple containing:
+            - board (str): The board to use for emulation, for example "brd4186c". (required).
+            - uart (str): The UART interface to interact with the emulated nodes (required).
+            - elf (str): The ELF file to be loaded into the emulated nodes (required).
+            - rng_seed (int or None): The random number generator seed to be used for emulation (default: None).
+            - log_file (str or None): The file to log all activity (default: None).
+
+    Raises:
+        SystemExit: If required arguments are not provided or parsing fails.
+    """
+    global _cli_rng_seed, _cli_log_file
+    parser = argparse.ArgumentParser(description="Silicon Labs pyrenode3-based testing library")
+    parser.add_argument("-b", "--board", help="The board to use for emulation.", required=True)
+    parser.add_argument("-u", "--uart", help="The UART interface to be used to interact with the emulated nodes", required=True)
+    parser.add_argument("-e", "--elf", help="The ELF file to be loaded into the emulated nodes", required=True)
+    parser.add_argument("-l", "--log_file", help="The file to log all activity", required=False)
+    parser.add_argument(
+        "-r", "--rng_seed",
+        help="The random number generator seed to be used for emulation (decimal or hex, e.g., 1234 or 0x1234ABCD)",
+        required=False,
+        type=lambda x: int(x, 0) if x is not None else None
+    )
+    args = parser.parse_args()
+    _cli_rng_seed = args.rng_seed
+    _cli_log_file = args.log_file
+    return args.board, args.uart, args.elf
+
+def create_emulation(debug=DEFAULT_DEBUG_PRINT, quantum_time=DEFAULT_QUANTUM_TIME, rng_seed=None, log_file=None):
+    """
+    Initializes and configures the emulation environment.
+
+    Parameters:
+        debug (callable, optional): Function to handle debug printing. Defaults to DEFAULT_DEBUG_PRINT.
+        quantum_time (float, optional): The quantum time interval in seconds for the emulation. Defaults to DEFAULT_QUANTUM_TIME.
+        rng_seed (int, optional): Seed value for the random number generator. If None, it shall use the seed parsed out from the command line arguments, if available. Otherwise, a random seed is used.
+        log_file (str, optional): The file to log all activity. If None, it shall use the log filename parsed out from the command line arguments, if available. Otherwise, a no logging is performed.
+
+    Side Effects:
+        - Sets global variables _e (Emulation instance), _m (Monitor instance), and _debug_print.
+        - Configures the emulation environment with serial execution, quantum time, and immediate advancement.
+        - Creates an IEEE 802.15.4 wireless medium.
+        - Sets the RNG seed if provided.
+        - Prints the RNG seed in hexadecimal format.
+
+    Returns:
+        None
+    """
+    global _e, _m, _debug_print
+    _debug_print = debug
+    _e = Emulation()
+    _m = Monitor()
+    _e.SetGlobalSerialExecution(True)
+    _e.SetQuantum(TimeInterval.FromSeconds(quantum_time))
+    _e.SetAdvanceImmediately(True)
+    _e.CreateIEEE802_15_4Medium("wireless")
+    if rng_seed is not None:
+        _e.SetSeed(rng_seed)
+    elif _cli_rng_seed is not None:
+        _e.SetSeed(_cli_rng_seed)
+    if log_file is not None:
+        set_log_file(log_file)
+    elif _cli_log_file is not None:
+        set_log_file(_cli_log_file)
+    print(f"RNG SEED: {hex(_e.GetSeed())}")
+
+def create_node(name, board, elf_file, tester_interface, tester_timeout = DEFAULT_TESTER_TIMEOUT, function_stubs=None):
+    """
+    Creates and configures a simulation node with the specified parameters.
+
+    Args:
+        name (str): The name of the node/machine to create.
+        board (str): The Silicon Labs emulated board to be used.
+        elf_file (str): Path to the ELF binary file to load into the node.
+        tester_interface (str): The name of the interface on the node to attach the TerminalTester to.
+        tester_timeout (int, optional): Timeout value for the TerminalTester. Defaults to DEFAULT_TESTER_TIMEOUT.
+        function_stubs (dict or None, optional): Optional dictionary of function stubs to add to the node.
+
+    Returns:
+        TerminalTester: An instance of TerminalTester attached to the specified interface.
+
+    Raises:
+        SystemExit: If no testerInterface is provided.
+
+    Side Effects:
+        - Adds the created node to internal mappings for machine and tester tracking.
+        - Loads the specified ELF files into the node.
+        - Connects the node's radio to the system bus via the wireless connector.
+        - Adds any provided function stubs to the node.
+    """
+    node = _e.add_mach(name)
+    node.load_repl("platforms/boards/silabs/" + board + ".repl")
+    node.load_elf(elf_file)
+    node.sysbus.cpu.VectorTableOffset = node.sysbus.GetSymbolAddress("__Vectors")
+    _m.execute(f"mach set \"{name}\"")
+    _m.execute("connector Connect sysbus.radio wireless")
+    if tester_interface is not None:
+        tester = TerminalTester(getattr(node.sysbus, tester_interface), tester_timeout)
+    else:
+        fail("No TerminalTester interface provided")
+    _machine_name_to_machine_mapping[name] = node
+    _tester_to_machine_mapping[tester] = node
+    _add_stubs(node, function_stubs)
+    return tester
+
+def wait_for(tester, line):
+    """
+    Waits for a specific line or pattern to appear in the tester's output.
+
+    Args:
+        tester: An object or identifier returned by the create_node function.
+        line (str): The string or regex pattern to wait for in the output.
+
+    Returns:
+        str: The line from the output that matches the given pattern.
+
+    Raises:
+        SystemExit: If the pattern is not found before a timeout occurs.
+
+    Side Effects:
+        Prints debug information about the wait status.
+    """
+    result = tester.WaitFor(pattern=line, treatAsRegex=True, includeUnfinishedLine=True, pauseEmulation=True)
+    if result is None or result.isFailingString:
+        fail(f"Timed out waiting for: {line}")
+    debug_print("WAIT_FOR: " + result.line)
+    return result.line
+
+def write_line(tester, line):
+    """
+    Sends a line of text to the tester and logs the action for debugging.
+
+    Args:
+        tester: An object or identifier returned by the create_node function.
+        line (str): The line of text to be sent to the tester.
+
+    Returns:
+        None
+    """
+    debug_print("WRITE_LINE: " + line)
+    result = tester.WriteLine(line)
+
+def delay(secs):
+    """
+    Pauses the execution for a specified number of seconds in the Renode simulation environment.
+
+    Args:
+        secs (float): The number of seconds to delay the simulation.
+
+    Raises:
+        Any exceptions raised by the underlying _e.RunFor or TimeInterval.FromSeconds methods.
+
+    Example:
+        delay(1.5)  # Delays the simulation for 1.5 seconds
+    """
+    _e.RunFor(TimeInterval.FromSeconds(secs))
+
+def get_machine_from_name(machine_name):
+    """
+    Retrieve a machine object based on its name.
+
+    Args:
+        machine_name (str): The name of the machine to retrieve.
+
+    Returns:
+        object: The machine object associated with the given name.
+
+    Raises:
+        KeyError: If the machine_name does not exist in the mapping.
+    """
+    return _machine_name_to_machine_mapping[machine_name]
+
+def get_machine_name_from_machine(machine):
+    """
+    Returns the name of a machine given its machine object.
+
+    Args:
+        machine: The machine object to look up.
+
+    Returns:
+        str or None: The name of the machine if found in the mapping, otherwise None.
+    """
+    for name, m in _machine_name_to_machine_mapping.items():
+        if m == machine:
+            return name
+    return None
+
+def get_machine_name_from_tester(tester):
+    """
+    Returns the machine name associated with a given tester.
+
+    Args:
+        tester: An object or identifier returned by the create_node function.
+
+    Returns:
+        The name of the machine associated with the provided tester.
+
+    Raises:
+        KeyError: If the tester is not found in the mapping.
+    """
+    return get_machine_name_from_machine(_tester_to_machine_mapping[tester])
+
+def get_machine_from_tester(tester):
+    """
+    Retrieve the machine associated with a given tester.
+
+    Args:
+        tester: An object or identifier returned by the create_node function.
+
+    Returns:
+        The machine associated with the provided tester, or None if the tester is not found in the mapping.
+    """
+    return _tester_to_machine_mapping.get(tester)
+
+def create_socket(tester, port, interface):
+    """
+    Creates a server socket terminal in the emulation environment and connects it to a specified interface.
+
+    Args:
+        tester: An object or identifier returned by the create_node function.
+        port (int): The port number on which to create the server socket.
+        interface (str): The name of the interface on the sysbus to connect to the socket.
+
+    Raises:
+        Exception: If any of the underlying commands fail to execute.
+
+    Side Effects:
+        - Sets the current machine context in the emulation environment.
+        - Creates a server socket terminal.
+        - Connects the specified sysbus interface to the created socket terminal.
+    """
+    machine_name = get_machine_name_from_tester(tester)
+    cli_name = f"cli_{machine_name}"
+    _m.execute(f"mach set \"{machine_name}\"")
+    _m.execute(f"emulation CreateServerSocketTerminal {port} \"{cli_name}\" false")
+    _m.execute(f"connector Connect sysbus.{interface} {cli_name}")
+
+def debug_print(message):
+    """
+    Prints a debug message to the console if debugging is enabled.
+
+    Args:
+        message (str): The message to be printed for debugging purposes.
+    """
+    if (_debug_print):
+        print(f"DEBUG: {message}")
+
+def enable_debug_prints(enable):
+    """
+    Enables or disables debug prints.
+
+    Args:
+        enable (bool): If True, enables debug prints; otherwise, disables them.
+    """
+    global _debug_print
+    _debug_print = enable
+
+def log_radio_activity_as_error():
+    """
+    Enable logging radio activity as errors in the Renode simulation environment.
+    """
+    for name, machine in _machine_name_to_machine_mapping.items():
+        machine.sysbus.radio.LogBasicRadioActivityAsError = True
+    
+def set_log_file(filename, log_level=DEFAULT_LOG_LEVEL):
+    """
+    Enables logging to a file. It enables logging for all peripherals of all nodes at the specified log level.
+
+    Args:
+        filename (str): The name of the file where all activity will be logged.
+        logLevel (int, optional): The logging level to set. Defaults to 1 (INFO).
+    """
+    if os.path.exists(filename):
+        os.remove(filename)
+    result = _m.execute(f"logFile \"{filename}\"")
+    result = _m.execute(f"logLevel {log_level}")
+
+def set_log_level(node, peripheral, log_level):
+    """
+    Sets the logging level for a specific peripheral of a node.
+
+    Args:
+        node: An object or identifier returned by the create_node function.
+        peripheral (str): The peripheral name to set the logging level for.
+        log_level (int): The logging level to set.
+    """
+    machine_name = get_machine_name_from_tester(node)
+    _m.execute(f"mach set \"{machine_name}\"")
+    _m.execute(f"logLevel {log_level} {peripheral}")
+
+def fail(message):
+    """
+    Fails the current test with an error message.
+    """
+    print("FAIL: " + message)
+    sys.exit(1)
+
+def emulation():
+    """
+    Returns the current emulation environment.
+    """
+    return _e
+
+def monitor():
+    """
+    Returns the current monitor instance.
+    """
+    return _m
+
+########################################################################
+# Internals
+########################################################################
+
+def _add_stubs(machine, function_stubs):
+    if function_stubs is not None:
+        for symbol in function_stubs:
+            addresses = machine.sysbus.TryGetAllSymbolAddresses(symbol)[1]
+            for addr in addresses:
+                Action = getattr(System, 'Action`2')
+                hook_action = Action[ICpuSupportingGdb, System.UInt64](_skip_function_hook)
+                machine.sysbus.cpu.AddHook(addr, hook_action)
+
+def _machine_name_from_cpu(cpu):
+    name = str(cpu).split(": ")[1]
+    name = name.split(".")[0]
+    return name
+
+def _skip_function_hook(cpu, addr):
+    cpu.PC = getattr(_e, _machine_name_from_cpu(cpu)).sysbus.cpu.LR

--- a/tests/platforms/SiLabs/connect.robot
+++ b/tests/platforms/SiLabs/connect.robot
@@ -1,0 +1,148 @@
+*** Variables ***
+# The ELF variable must be set from command line to the Connect MAC Mode ELF file to be used. 
+# Example of SLC generation line for board 4186c (EFR32xG24): 
+# slc generate -s $GSDK_PATH -p $GSDK_PATH/app/connect/example/connect_soc_mac_mode_device/connect_soc_mac_mode_device.slcp -d path_to_dest/ --with brd4186c,rail_lib_singleprotocol_debug --without toolchain_gcc_lto
+
+${ELF}                          connect_soc_mac_mode_device.out
+${BOARD}                        brd4186c
+${QUANTUM_TIME}                 0.000050
+${RNG_SEED}                     0
+${UART}                         usart0
+${DEFAULT_UART_TIMEOUT}         5
+${PROMPT}                       >
+${PAN_ID}                       0xABCD
+${NODE1_SHORT_ID}               0x1111
+${NODE2_SHORT_ID}               0x2222
+${POWER}                        0
+${CHANNEL}                      15
+${KEY}                          AAAAAAAAAAAAAAAABBBBBBBBBBBBBBBB
+${TEST_PAYLOAD}                 AA BB CC DD EE FF 11 22 33 44 55 66 77 88 99
+${SHORT_SHORT_MASK}             0x0122
+${SHORT_LONG_MASK}              0x0132
+${LONG_SHORT_MASK}              0x0123
+${LONG_LONG_MASK}               0x0133
+
+
+*** Keywords ***
+Initial Setup
+    Execute Command             emulation SetGlobalSerialExecution true
+    Execute Command             emulation SetQuantum "${QUANTUM_TIME}"
+    Execute Command             emulation SetAdvanceImmediately true    
+    IF  ${RNG_SEED} > 0
+        Execute Command         emulation SetSeed ${RNG_SEED}
+    END
+    ${RNG_SEED}=                Execute Command  emulation GetSeed
+    Log To Console              RNG SEED: ${RNG_SEED}
+    Execute Command             emulation CreateIEEE802_15_4Medium "wireless"
+    Set Default Uart Timeout    ${DEFAULT_UART_TIMEOUT}
+    Execute Command             logLevel 3
+
+Create Node
+    [Arguments]  ${machine_name}
+    [Return]     ${tester_id}
+    Execute Command             mach clear
+    Execute Command             mach create "${machine_name}"
+    Execute Command             machine LoadPlatformDescription @platforms/boards/silabs/${BOARD}.repl
+    Execute Command             sysbus LoadELF @${ELF}
+    Execute Command             sysbus LogAllPeripheralsAccess false
+    Execute Command             connector Connect sysbus.radio wireless
+    ${tester_id}=               Create Terminal Tester  sysbus.${UART}  machine=${machine_name}  defaultPauseEmulation=true
+    # This command togehter with using the "--enable-xwt" option when launching renote-test 
+    # pops up a UART shell for each node and allows to see the nodes CLI activity.
+    #Execute Command             showAnalyzer sysbus.${UART}
+
+Commission Network
+    [Arguments]  ${tester}  ${node_id}  ${pan_id}  ${power}  ${channel}
+    Write Line To Uart          commission 6 ${node_id} ${pan_id} ${power} ${channel}  testerId=${tester}
+    Wait For Line On Uart       Node parameters commissioned  testerId=${tester}
+    Write Line To Uart          info  testerId=${tester}
+    Wait For Line On Uart       Network state: 0x02  testerId=${tester}
+    Wait For Line On Uart       Node type: 0x06  testerId=${tester}
+    Wait For Line On Uart       Node id: ${node_id}  testerId=${tester}
+    Wait For Line On Uart       Pan id: ${pan_id}  testerId=${tester}
+    Wait For Line On Uart       Channel: ${channel}  testerId=${tester}
+
+Get Node Long Id
+    [Arguments]  ${tester}
+    [Return]     ${long_id}
+    Write Line To Uart          info  testerId=${tester}
+    ${s}=                       Wait For Line On Uart  Node Long id:  testerId=${tester}
+    ${long_id}=                 Get Substring  ${s.line}  -16
+
+Set Key
+    [Arguments]  ${tester}  ${key}
+    Write Line To Uart          set_key {${key}}  testerId=${tester}
+    Wait For Line On Uart       Security key set successful  testerId=${tester}
+
+Set Security
+    [Arguments]  ${tester}  ${enable}
+    IF  ${enable} == True
+        Write Line To Uart      set_options 0x03  testerId=${tester}
+    ELSE
+        Write Line To Uart      set_options 0x02  testerId=${tester}
+    END
+    Wait For Line On Uart       Send options set:  testerId=${tester}
+
+Set Security Mapping
+    [Arguments]  ${tester}  ${remote_short_id}  ${remote_long_id}
+    Write Line To Uart          set_security_mapping ${remote_short_id} {${remote_long_id}}  testerId=${tester}
+    Wait For Line On Uart       Security mapping set  testerId=${tester}
+
+Send Test Message
+    [Arguments]  ${addr_mask}  ${tx_tester}  ${src_short}  ${src_long}  ${rx_tester}  ${dst_short}  ${dst_long}
+    Write Line To Uart          send ${addr_mask} ${src_short} {${src_long}} ${dst_short} {${dst_long}} ${PAN_ID} ${PAN_ID} {${TEST_PAYLOAD}}  ${tx_tester}
+    Wait For Line On Uart       MAC frame submitted  testerId=${tx_tester}
+    Wait For Line On Uart       MAC RX: Data from.*:{ ${TEST_PAYLOAD}}  testerId=${rx_tester}  treatAsRegex=true
+    Should Not Be On Uart       MAC TX:  testerId=${tx_tester}  timeout=0.25
+
+*** Test Cases ***
+Connect Mac Mode Basic Test
+    Initial Setup
+
+    ${NODE1_TESTER_ID}=         Create Node  node1
+    ${NODE2_TESTER_ID}=         Create Node  node2
+
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE1_TESTER_ID}
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE2_TESTER_ID}
+
+    ${NODE1_LONG_ID}=           Get Node Long Id  ${NODE1_TESTER_ID}
+    ${NODE2_LONG_ID}=           Get Node Long Id  ${NODE2_TESTER_ID}
+
+    Commission Network          ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${PAN_ID}  ${POWER}  ${CHANNEL}
+    Commission Network          ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${PAN_ID}  ${POWER}  ${CHANNEL}
+
+    Set Security                ${NODE1_TESTER_ID}  False
+    Set Security                ${NODE2_TESTER_ID}  False
+
+    Send Test Message           ${SHORT_SHORT_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${SHORT_SHORT_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Send Test Message           ${LONG_SHORT_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${LONG_SHORT_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Send Test Message           ${SHORT_LONG_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${SHORT_LONG_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Send Test Message           ${LONG_LONG_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${LONG_LONG_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Set Key                     ${NODE1_TESTER_ID}  ${KEY}
+    Set Key                     ${NODE2_TESTER_ID}  ${KEY}
+
+    Set Security                ${NODE1_TESTER_ID}  True
+    Set Security                ${NODE2_TESTER_ID}  True
+
+    Set Security Mapping        ${NODE1_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Set Security Mapping        ${NODE2_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Send Test Message           ${SHORT_SHORT_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${SHORT_SHORT_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Send Test Message           ${LONG_SHORT_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${LONG_SHORT_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Send Test Message           ${SHORT_LONG_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${SHORT_LONG_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}
+
+    Send Test Message           ${LONG_LONG_MASK}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}
+    Send Test Message           ${LONG_LONG_MASK}  ${NODE2_TESTER_ID}  ${NODE2_SHORT_ID}  ${NODE2_LONG_ID}  ${NODE1_TESTER_ID}  ${NODE1_SHORT_ID}  ${NODE1_LONG_ID}

--- a/tests/platforms/SiLabs/openthread.robot
+++ b/tests/platforms/SiLabs/openthread.robot
@@ -1,0 +1,90 @@
+*** Variables ***
+# The ELF variable must be set from command line to the OpenThread FTD CLI ELF file to be used. 
+${URI}                          @https://artifactory.silabs.net/artifactory/renode-production/prebuilt/xg24
+${ELF}                          ${URI}/ot-cli-ftd.out
+${BOARD}                        brd4186c
+${QUANTUM_TIME}                 0.000050
+${RNG_SEED}                     0
+${UART}                         usart0
+${DEFAULT_UART_TIMEOUT}         10
+${PROMPT}                       >
+
+*** Keywords ***
+Initial Setup
+    Execute Command             emulation SetGlobalSerialExecution true
+    IF  ${RNG_SEED} > 0
+        Execute Command         emulation SetSeed ${RNG_SEED}
+    END
+    ${RNG_SEED}=                Execute Command  emulation GetSeed
+    Log To Console              RNG SEED: ${RNG_SEED}
+    Execute Command             emulation SetQuantum "${QUANTUM_TIME}"
+    Execute Command             emulation SetAdvanceImmediately true
+    Execute Command             emulation CreateIEEE802_15_4Medium "wireless"
+    Set Default Uart Timeout    ${DEFAULT_UART_TIMEOUT}
+    Execute Command             logLevel 3
+
+Create Node
+    [Arguments]  ${machine_name}
+    [Return]     ${tester_id}
+    Execute Command             mach clear
+    Execute Command             mach create "${machine_name}"
+    Execute Command             machine LoadPlatformDescription @platforms/boards/silabs/${BOARD}.repl
+    Execute Command             sysbus LoadELF @${ELF}
+    Execute Command             sysbus LogAllPeripheralsAccess false
+    Execute Command             connector Connect sysbus.radio wireless
+    ${tester_id}=               Create Terminal Tester  sysbus.${UART}  machine=${machine_name}  defaultPauseEmulation=true
+    # This command togehter with using the "--enable-xwt" option when launching renote-test 
+    # pops up a UART shell for each node and allows to see the nodes CLI activity.
+    #Execute Command             showAnalyzer ${UART}
+
+Leader Start
+    [Arguments]  ${tester}
+    [Return]     ${key.line}
+    Write Line To Uart          dataset init new  testerId=${tester}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+    Write Line To Uart          dataset commit active  testerId=${tester}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+    Write Line To Uart          dataset networkkey  testerId=${tester}
+    ${key}                      Wait For Line On Uart  ^.{32}$  testerId=${tester}  treatAsRegex=true  timeout=5
+    Log                         parsed key ${key.line}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+    Write Line To Uart          ifconfig up  testerId=${tester}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+    Write Line To Uart          thread start  testerId=${tester}
+    Wait For Line On Uart       Role detached -> leader  testerId=${tester}  timeout=30
+
+    Write Line To Uart          state  testerId=${tester}
+    Wait For Line On Uart       leader  testerId=${tester}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+Router Start
+    [Arguments]  ${tester}  ${network_key}
+    Write Line To Uart          dataset networkkey ${network_key}  testerId=${tester}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+    Write Line To Uart          dataset commit active  testerId=${tester}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+    Write Line To Uart          ifconfig up  testerId=${tester}
+    Wait For Line On Uart       Done  testerId=${tester}
+
+    Write Line To Uart          thread start  testerId=${tester}
+    Wait For Line On Uart       Role detached -> child  testerId=${tester}  timeout=30
+
+*** Test Cases ***
+Open Thread FTD Basic Test
+    Initial Setup
+
+    ${NODE1_TESTER_ID}=         Create Node  node1
+    ${NODE2_TESTER_ID}=         Create Node  node2
+
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE1_TESTER_ID}
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE2_TESTER_ID}
+
+    ${network_key}              Leader Start  ${NODE1_TESTER_ID}
+
+    Router Start                ${NODE2_TESTER_ID}  ${network_key}

--- a/tests/platforms/SiLabs/railtest.robot
+++ b/tests/platforms/SiLabs/railtest.robot
@@ -1,0 +1,149 @@
+*** Variables ***
+# The ELF variable must be set from command line to the Railtest ELF file to be used. 
+# Example of SLC generation line for board 4186c (EFR32xG24): 
+# slc generate -s GSDK_PATH/ -p GSDK_PATH/app/rail/example/soc/rail_soc_railtest/rail_soc_railtest.slcp -d path_to_generation_directory/ --with brd4186c,rail_lib_multiprotocol_debug --without toolchain_gcc_lto
+${ELF}                          railtest.out
+${BOARD}                        brd4186c
+${QUANTUM_TIME}                 0.000020
+${RNG_SEED}                     0
+${UART}                         eusart0
+${DEFAULT_UART_TIMEOUT}         1
+${PROMPT}                       >
+
+*** Keywords ***
+Initial Setup
+    Execute Command             emulation SetGlobalSerialExecution true
+    Execute Command             emulation SetQuantum "${QUANTUM_TIME}"
+    Execute Command             emulation SetAdvanceImmediately true
+    IF  ${RNG_SEED} > 0
+        Execute Command         emulation SetSeed ${RNG_SEED}
+    END
+    ${RNG_SEED}=                Execute Command  emulation GetSeed
+    Log To Console              RNG SEED: ${RNG_SEED}
+    Execute Command             emulation CreateBLEMedium "wireless"
+    Set Default Uart Timeout    ${DEFAULT_UART_TIMEOUT}
+    Execute Command             logLevel 1
+
+Create Node
+    [Arguments]  ${machine_name}
+    [Return]     ${tester_id}
+    Execute Command             mach clear
+    Execute Command             mach create "${machine_name}"
+    Execute Command             machine LoadPlatformDescription @platforms/boards/silabs/${BOARD}.repl
+    Execute Command             sysbus LoadELF @${ELF}
+    Execute Command             sysbus.cpu VectorTableOffset `sysbus GetSymbolAddress "__Vectors"`
+    Execute Command             sysbus LogAllPeripheralsAccess false
+    Execute Command             connector Connect sysbus.radio wireless
+    ${tester_id}=               Create Terminal Tester  sysbus.${UART}  machine=${machine_name}  defaultPauseEmulation=true
+    Execute Command             logLevel 3
+    # This command togehter with using the "--enable-xwt" option when launching renote-test 
+    # pops up a UART shell for each node and allows to see the nodes CLI activity.
+    #Execute Command             showAnalyzer sysbus.${UART}
+    
+Send Packet
+    [Arguments]  ${tx_tester}  ${rx_tester}  ${expect_rx}
+    Write Line To Uart          tx 1  testerId=${tx_tester}
+    IF  ${expect_rx} == True
+        Wait For Line On Uart   (rxPacket)  testerId=${rx_tester}
+    ELSE
+        Should Not Be On Uart   (rxPacket)  testerId=${rx_tester}  timeout=0.25
+    END
+
+Enable Rx
+    [Arguments]  ${tester}  ${enable}
+    IF  ${enable} == True
+        Write Line To Uart      rx 1  testerId=${tester}
+        Wait For Line On Uart   {Rx:Enabled}{Idle:Disabled}  testerId=${tester}
+    ELSE
+        Write Line To Uart      rx 0  testerId=${tester}
+        Wait For Line On Uart   {Rx:Disabled}{Idle:Enabled}  testerId=${tester}
+    END
+
+Set Channel
+    [Arguments]  ${tester}  ${channel}
+    Write Line To Uart          setChannel ${channel}  testerId=${tester}
+    Wait For Line On Uart       {channel:${channel}}  testerId=${tester}
+
+Check Radio State
+    [Arguments]  ${tester}  ${state}
+    Write Line To Uart          getRadioState  testerId=${tester}
+    Wait For Line On Uart       radioState:${state}  testerId=${tester}
+
+Configure 802.15.4 Mode
+    [Arguments]  ${tester}
+    Write Line To Uart          enable802154 rx 100 192 864  testerId=${tester}
+    Wait For Line On Uart       {idleTiming:100}{turnaroundTime:192}{ackTimeout:864}  testerId=${tester}
+    Write Line To Uart          config2p4GHz802154  testerId=${tester}
+    Wait For Line On Uart       {802.15.4:Enabled}  testerId=${tester}
+    Write Line To Uart          acceptFrames 1 1 1 1  testerId=${tester}
+    Wait For Line On Uart       {CommandFrame:Enabled}{AckFrame:Enabled}{DataFrame:Enabled}{BeaconFrame:Enabled}  testerId=${tester}
+    Write Line To Uart          setPromiscuousMode 0  testerId=${tester}
+    Wait For Line On Uart       {PromiscuousMode:Disabled}  testerId=${tester}
+
+Set 802.14.4 Fields
+    [Arguments]  ${tester}  ${pan_id}  ${short_id}
+    Write Line To Uart          setpanid802154 ${pan_id} 0  testerId=${tester}
+    Wait For Line On Uart       {802.15.4PanId:Success}  testerId=${tester}
+    Write Line To Uart          setshortaddr802154 ${short_id} 0  testerId=${tester}
+    Wait For Line On Uart       {802.15.4ShortAddress:Success}  testerId=${tester}
+
+*** Test Cases ***
+Basic Communication Test
+    Initial Setup
+
+    ${NODE1_TESTER_ID}=         Create Node  node1
+    ${NODE2_TESTER_ID}=         Create Node  node2
+
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE1_TESTER_ID}
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE2_TESTER_ID}
+    Check Radio State           ${NODE1_TESTER_ID}  Rx
+    Check Radio State           ${NODE2_TESTER_ID}  Rx
+
+    # Nodes on the same channel: send packets, expect reception
+    Set Channel                 ${NODE1_TESTER_ID}  5
+    Set Channel                 ${NODE2_TESTER_ID}  5
+    Send Packet                 ${NODE1_TESTER_ID}  ${NODE2_TESTER_ID}  True
+    Send Packet                 ${NODE2_TESTER_ID}  ${NODE1_TESTER_ID}  True
+
+    # Nodes on different channels: send packets, expect NO reception
+    Set Channel                 ${NODE2_TESTER_ID}  7
+    Send Packet                 ${NODE1_TESTER_ID}  ${NODE2_TESTER_ID}  False
+    Send Packet                 ${NODE2_TESTER_ID}  ${NODE1_TESTER_ID}  False
+
+    # Nodes on the same channel: send packets, expect reception
+    Set Channel                 ${NODE2_TESTER_ID}  5
+    Send Packet                 ${NODE1_TESTER_ID}  ${NODE2_TESTER_ID}  True
+    Send Packet                 ${NODE2_TESTER_ID}  ${NODE1_TESTER_ID}  True
+
+    # Node 2 radio is off: send a packet, expect NO reception
+    Enable Rx                   ${NODE2_TESTER_ID}  False
+    Check Radio State           ${NODE2_TESTER_ID}  Idle
+    Send Packet                 ${NODE1_TESTER_ID}  ${NODE2_TESTER_ID}  False
+
+802.15.4 Auto-Acking Test
+    Initial Setup
+
+    ${NODE1_TESTER_ID}=         Create Node  node1
+    ${NODE2_TESTER_ID}=         Create Node  node2
+
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE1_TESTER_ID}
+    Wait For Prompt On Uart     ${PROMPT}  testerId=${NODE2_TESTER_ID}
+
+    # Node 1 (RX) config
+    Enable Rx                   ${NODE1_TESTER_ID}  False
+    Configure 802.15.4 Mode     ${NODE1_TESTER_ID}
+    Set Channel                 ${NODE1_TESTER_ID}  24
+    Set 802.14.4 Fields         ${NODE1_TESTER_ID}  0x5555  0xAAAA
+    Enable Rx                   ${NODE1_TESTER_ID}  True
+
+    # Node 2 (TX) config
+    Enable Rx                   ${NODE2_TESTER_ID}  False
+    Configure 802.15.4 Mode     ${NODE2_TESTER_ID}
+    Set Channel                 ${NODE2_TESTER_ID}  24
+    Write Line To Uart          configTxOptions 1  testerId=${NODE2_TESTER_ID}
+    Wait For Line On Uart       {waitForAck:True}  testerId=${NODE2_TESTER_ID}
+
+    # Node 2 TX a packet to Node 1, gets an ACK back
+    Write Line To Uart          settxpayload 0 14 0x23 0x88 0xbe 0x55 0x55 0xAA 0xAA 0x55 0x55 0xAA 0xAA 0x04  testerId=${NODE2_TESTER_ID}
+    Write Line To Uart          tx 1  testerId=${NODE2_TESTER_ID}
+    Wait For Line On Uart       (rxPacket).*{isAck:True}  testerId=${NODE2_TESTER_ID}  treatAsRegex=true

--- a/tests/platforms/SiLabs/zigbee.py
+++ b/tests/platforms/SiLabs/zigbee.py
@@ -1,0 +1,83 @@
+from common import test_lib
+
+################################################
+# Globals
+################################################
+
+QUANTUM_TIME = 0.000050
+PROMPT = "z3_light"
+PAN_ID = 0xABCD
+POWER = 0
+CHANNEL = 15
+NUM_ZIGBEE_PACKETS = 10
+STUBS = ["sl_zigbee_af_main_init_cb", "sl_zigbee_af_stack_status_cb"]
+DEBUG = True
+
+################################################
+# Utility functions
+################################################
+
+def form_network(node, pan_id, power, channel):
+    test_lib.write_line(node, f"plugin network-creator form 0 {pan_id} {power} {channel}")
+    line = test_lib.wait_for(node, "NETWORK_UP 0x....")
+    return line[-6:]
+
+def join_network(node):
+    test_lib.write_line(node, "plugin network-steering start 1")
+    test_lib.wait_for(node, "NWK Steering: Start:")
+    line = test_lib.wait_for(node, "NETWORK_UP 0x....")
+    test_lib.wait_for(node, "Join network complete: 0x00")
+    return line[-6:]
+
+def open_network(node):
+    test_lib.write_line(node, "plugin network-creator-security open-network")
+    test_lib.wait_for(node, "Open network: 0x00")
+    test_lib.wait_for(node, "NETWORK_OPENED")
+
+def leave_network(node):
+    test_lib.write_line(node, "plugin network-steering stop")
+    test_lib.wait_for(node, "NWK Steering: Stop")
+    test_lib.write_line(node, "plugin network-creator stop")
+    test_lib.wait_for(node, "NWK Creator: Stop")
+    test_lib.write_line(node, "network leave")
+    line = test_lib.wait_for(node, "leave 0x.")
+    if "0x0" in line:
+        test_lib.wait_for(node, "NETWORK_DOWN")
+
+def run_throughput_test(node, dest_node_id):
+    test_lib.write_line(node, f"network_test start_zigbee_test 70 {NUM_ZIGBEE_PACKETS} 0 3 {dest_node_id} 0x00")
+    test_lib.wait_for(node, "ZigBee TX test started")
+    line = test_lib.wait_for(node, "Success messages:.*out of " + str(NUM_ZIGBEE_PACKETS))
+    line = line.split(": ")[1]  # Get "N out of 10"
+    line = line.split(" ")[0]  # Get "N"
+    assert(int(line) / NUM_ZIGBEE_PACKETS >= 0.8)
+
+################################################
+# Test
+################################################
+
+board, uart, elf = test_lib.parse_arguments()
+test_lib.create_emulation(debug=DEBUG, quantum_time=QUANTUM_TIME)
+
+node1 = test_lib.create_node("node1", board, elf, uart, function_stubs=STUBS)
+node2 = test_lib.create_node("node2", board, elf, uart, function_stubs=STUBS)
+
+test_lib.wait_for(node1, PROMPT)
+test_lib.wait_for(node2, PROMPT)
+
+node1_short_id = form_network(node1, PAN_ID, POWER, CHANNEL)
+open_network(node1)
+node2_short_id = join_network(node2)
+
+run_throughput_test(node1, node2_short_id)
+run_throughput_test(node2, node1_short_id)
+
+leave_network(node1)
+leave_network(node2)
+
+node2_short_id = form_network(node2, PAN_ID, POWER, CHANNEL)
+open_network(node2)
+node1_short_id = join_network(node1)
+
+run_throughput_test(node1, node2_short_id)
+run_throughput_test(node2, node1_short_id)


### PR DESCRIPTION
- Added support for Silicon Labs SiXG301
- Renamed all Silicon Labs models to the agreed convention of SiLabs_IPNAME_IPVERSION.cs
- Miscellaneous improvements to EFR32xG24 and EFR32xG26 models
- Added robot tests and pyrenode3 tests for typical Silicon Labs use cases such as: Railtest, Zigbee, Connect, Openthread, BLE NCP and Zigbee+BLE dynamic multiprotocol

