### PR TITLE
STM32F4 SPI shouldn't have a FIFO

### DIFF
--- a/platforms/cpus/stm32f4.repl
+++ b/platforms/cpus/stm32f4.repl
@@ -127,12 +127,15 @@ rom2: Memory.MappedMemory @ sysbus 0x1FFFC400
     size: 0x3C00
 
 spi1: SPI.STM32SPI @ sysbus 0x40013000
+    bufferCapacity: 1
 
 spi2: SPI.STM32SPI @ sysbus 0x40003800
     IRQ->nvic@35
     DMARecieve->dma1@3
+    bufferCapacity: 1
 
 spi3: SPI.STM32SPI @ sysbus 0x40003C00
+    bufferCapacity: 1
 
 i2c1: I2C.STM32F4_I2C @ sysbus 0x40005400
     EventInterrupt -> nvic@31


### PR DESCRIPTION
Unlike the H7 series, the F4 has no internal SPI FIFO on rx or tx. If a large buffer is transmitted, it will fill renode's SPI RX buffer with garbage data. The HAL assumes no FIFO and thus only reads the dr once at the end of transmission, which leaves 3 garbage bytes in renode's buffer. Then, future bytes received will be out of sync as the past garbage is pushed out of the queue first.