### PR TITLE
kendryte_k210: Fix CPU1 ISA configuration to match CPU2

### DIFF
--- a/platforms/cpus/kendryte_k210.repl
+++ b/platforms/cpus/kendryte_k210.repl
@@ -5,7 +5,7 @@ rom: Memory.MappedMemory @ {
     size: 0x2000000
 
 cpu1: CPU.RiscV64 @ sysbus
-    cpuType: "rv64imacfd_zicsr_zifencei"
+    cpuType: "rv64imafdc_zicsr_zifencei"
     privilegedArchitecture: PrivilegedArchitecture.Priv1_10
     timeProvider: clint
     hartId: 0


### PR DESCRIPTION

### Related issue

N/A - Internal configuration consistency fix

### Description

This PR is a style fix that corrects the RISC-V ISA configuration inconsistency in the Kendryte K210 platform.

### Usage example

N/A

### Additional information

- Files changed: platforms/cpus/kendryte_k210.repl (1 line changed)
- Scope: Platform configuration fix for dual-core K210 SoC
- Impact: Both cores now have identical, standards-compliant RISC-V ISA configurations
