### PR TITLE
cosim: multi-instance DPI support and IRQ preemption of sync_time

### DIFF
--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/modules/renode.sv
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/modules/renode.sv
@@ -148,11 +148,53 @@ module renode #(
   endtask
 
   task static sync_time(time time_to_elapse);
-    renode_time = renode_time + time_to_elapse;
-    while ($time < renode_time) @(clk);
+    // NOTE: no initializers on local vars — static task vars are only
+    // initialized once at time 0, not on every call. Use assignments below.
+    time tick_start;
+    time ticks_done;
+    time current_target;
+    bit preempted;
 
-    runtime.connection.send_to_async_receiver(message_t'{renode_pkg::tickClock, 0, 0, renode_pkg::no_peripheral_index});
-    runtime.connection.log(renode_pkg::LogNoisy, $sformatf("Simulation time synced to %t", $realtime));
+    tick_start     = renode_time;
+    current_target = time_to_elapse;
+    preempted      = 0;
+
+    renode_time = renode_time + time_to_elapse;
+    while ($time < renode_time) begin
+      @(clk);
+
+      if (runtime.interrupt_preempt_requested) begin
+        runtime.interrupt_preempt_requested = 0;
+        ticks_done  = $time - tick_start;
+        renode_time = $time;  // causes while loop to exit
+
+        // Send early ack so Renode unblocks the CPU immediately.
+        // This is the only ack for this batch — do NOT send a second one
+        // at the bottom. The simulation runs freely after returning; the
+        // next TickClock arrives via the normal receive_and_handle_message
+        // path at the next posedge clk.
+        runtime.connection.send_to_async_receiver(message_t'{
+            renode_pkg::tickClock,
+            renode_pkg::address_t'(0),
+            renode_pkg::data_t'(ticks_done),
+            renode_pkg::no_peripheral_index});
+        runtime.connection.log(renode_pkg::LogNoisy,
+            $sformatf("IRQ preempted sync_time after %0d of %0d ticks",
+                      ticks_done, current_target));
+        preempted = 1;
+        // renode_time == $time → while condition false → loop exits
+      end
+    end
+
+    if (!preempted) begin
+      runtime.connection.send_to_async_receiver(message_t'{
+          renode_pkg::tickClock,
+          renode_pkg::address_t'(0),
+          renode_pkg::data_t'(current_target),
+          renode_pkg::no_peripheral_index});
+      runtime.connection.log(renode_pkg::LogNoisy,
+          $sformatf("Simulation time synced to %t", $realtime));
+    end
   endtask
 
   task automatic read_from_bus(address_t address, valid_bits_e data_bits, int peripheral_index);

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/modules/renode_inputs.sv
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/modules/renode_inputs.sv
@@ -42,6 +42,9 @@ module renode_inputs #(
               renode_pkg::data_t'(inputs[addr]),
               renode_pkg::no_peripheral_index
             });
+          // Ask sync_time to send an early TickClock ack so Renode can
+          // process this interrupt without waiting for the full tick window.
+          runtime.interrupt_preempt_requested = 1;
         end
       end
       inputs_prev <= inputs;

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
@@ -14,7 +14,7 @@ package renode_pkg;
   typedef enum int {
     // The included file contains enumerators of the action type used by the Renode protocol.
     // The values must be in sync with ActionType from Renode (defined in C#).
-    `include "renode_action_enumerators.svh"
+    `include "./includes/renode_action_enumerators.svh"
   } action_e;
 
   const int no_peripheral_index = -1;
@@ -41,37 +41,46 @@ package renode_pkg;
     LogError = 3
   } log_level_e;
 
-  import "DPI-C" function void renodeDPIConnect(
+  import "DPI-C" function void renodeDPIConnectInst(
+    int id,
     int receiverPort,
     int senderPort,
     string address
   );
 
-  import "DPI-C" function void renodeDPIDisconnect();
+  import "DPI-C" function void renodeDPIDisconnectInst(int id);
 
-  import "DPI-C" function bit renodeDPIIsConnected();
+  import "DPI-C" function bit renodeDPIIsConnectedInst(int id);
 
-  import "DPI-C" function bit renodeDPILog(
-    int logLevel,
+  import "DPI-C" function bit renodeDPILogInst(
+    int id, 
+    int logLevel, 
     string data
   );
 
-  import "DPI-C" function bit renodeDPIReceive(
-    output action_e action,
+  import "DPI-C" function bit renodeDPIReceiveInst(
+    int id, output action_e action,
     output address_t address,
     output data_t data,
-    output int peripheralIndex 
+    output int peripheralIndex
+    );
+
+  import "DPI-C" function bit renodeDPITryReceiveInst(
+    int id, output action_e action,
+    output address_t address,
+    output data_t data,
+    output int peripheralIndex
   );
 
-  import "DPI-C" function bit renodeDPISend(
-    action_e action,
+  import "DPI-C" function bit renodeDPISendInst(
+    int id, action_e action,
     address_t address,
     data_t data,
     int peripheralIndex
   );
 
-  import "DPI-C" function bit renodeDPISendToAsync(
-    action_e action,
+  import "DPI-C" function bit renodeDPISendToAsyncInst(
+    int id, action_e action,
     address_t address,
     data_t data,
     int peripheralIndex
@@ -102,13 +111,14 @@ package renode_pkg;
 
   class renode_connection;
     semaphore exclusive_receive = new(1);
-
-    function new();
+    int instance_id; 
+    function new(int id = 0);
+      instance_id = id;
       $timeformat(0, 9, "s", 0);
     endfunction
 
     function void connect(int receiver_port, int sender_port, string address);
-      renodeDPIConnect(receiver_port, sender_port, address);
+      renodeDPIConnectInst(instance_id, receiver_port, sender_port, address);
       if(is_connected())
         $display("Renode at %t: Connected using the socket based interface", $realtime);
       else
@@ -116,7 +126,7 @@ package renode_pkg;
     endfunction
 
     function bit is_connected();
-      return renodeDPIIsConnected();
+      return renodeDPIIsConnectedInst(instance_id);
     endfunction
 
     function void fatal_error(string message);
@@ -141,18 +151,19 @@ package renode_pkg;
 `ifdef RENODE_DEBUG
       $display("Renode at %t logs: %s", $realtime, message);
 `endif
-      if(!renodeDPILog(log_level, message)) begin
+      if(!renodeDPILogInst(instance_id, log_level, message)) begin
         $display("Renode at %t: Unable to send the log: %s", $realtime, message);
       end
     endfunction
 
     function void receive(output message_t message);
-      bit is_received = try_receive(message);
+      bit is_received = renodeDPIReceiveInst(instance_id, message.action, message.address, message.data, message.peripheral_index);
       if (!is_received) fatal_error("Unable to receive a message.");
     endfunction
 
+    // Non-blocking: returns 0 immediately if no message is ready on the socket.
     function bit try_receive(output message_t message);
-      bit is_received = renodeDPIReceive(message.action, message.address, message.data, message.peripheral_index);
+      bit is_received = renodeDPITryReceiveInst(instance_id, message.action, message.address, message.data, message.peripheral_index);
       if(is_received) begin
 `ifdef RENODE_DEBUG
       log(LogDebug, $sformatf("Received action %0s, address = 'h%h, data = 'h%h, peripheral index: %d", message.action.name(), message.address, message.data, message.peripheral_index));
@@ -165,18 +176,18 @@ package renode_pkg;
 `ifdef RENODE_DEBUG
       log(LogDebug, $sformatf("Sent action %0s, address = 'h%h, data = 'h%h, peripheral index: %d", message.action.name(), message.address, message.data, message.peripheral_index));
 `endif
-      if (!renodeDPISend(message.action, message.address, message.data, message.peripheral_index)) fatal_error("Unexpected channel disconnection");
+      if (!renodeDPISendInst(instance_id, message.action, message.address, message.data, message.peripheral_index)) fatal_error("Unexpected channel disconnection");
     endfunction
 
     function void send_to_async_receiver(message_t message);
 `ifdef RENODE_DEBUG
       log(LogDebug, $sformatf("Sent async action %0s, address = 'h%h, data = 'h%h, peripheral index: %d", message.action.name(), message.address, message.data, message.peripheral_index));
 `endif
-      if (!renodeDPISendToAsync(message.action, message.address, message.data, message.peripheral_index)) fatal_error("Unexpected channel disconnection");
+      if (!renodeDPISendToAsyncInst(instance_id, message.action, message.address, message.data, message.peripheral_index)) fatal_error("Unexpected channel disconnection");
     endfunction
 
     local function void disconnect();
-      renodeDPIDisconnect();
+      renodeDPIDisconnectInst(instance_id);
     endfunction
 
     local function void handle_disconnect();
@@ -266,14 +277,22 @@ package renode_pkg;
     const string ReceiverPortArgName = "RENODE_RECEIVER_PORT";
     const string SenderPortArgName = "RENODE_SENDER_PORT";
     const string AddressArgName = "RENODE_ADDRESS";
+    
+    int instance_id;
+    renode_connection connection;
 
-    renode_connection connection = new();
+    // Set by renode_inputs when an interrupt fires during sync_time.
+    // sync_time checks this flag to send an early partial TickClock ack so
+    // Renode can process the interrupt immediately rather than waiting for the
+    // full tick window to complete.
+    bit interrupt_preempt_requested = 0;
 
-    // Initialized in the constructor
+    // Initialized by the Renode module
     bus_connection controllers[];
     bus_connection peripherals[];
 
-    function new(int RenodeToCosimCount, int CosimToRenodeCount);
+    function new(int id, int RenodeToCosimCount, int CosimToRenodeCount); 
+      connection = new(id);
       controllers = new[RenodeToCosimCount];
       foreach(controllers[i]) begin
         controllers[i] = new();
@@ -297,6 +316,10 @@ package renode_pkg;
       else begin
         connection.connect(receiver_port, sender_port, address);
       end
+    endfunction
+
+    function void connect_automatic(int receiver_port, int sender_port, string address); 
+      connection.connect(receiver_port, sender_port, address);
     endfunction
 
     function bit is_connected();

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/communication_channel.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/communication_channel.h
@@ -13,6 +13,7 @@ class CommunicationChannel
 public:
   virtual void log(int logLevel, const char* data) = 0;
   virtual Protocol* receive() = 0;
+  virtual bool tryReceive(Protocol* message) { return false; }
   virtual void sendMain(const Protocol message) = 0;
   virtual void sendSender(const Protocol message) = 0;
   virtual bool isConnected() = 0;

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
@@ -53,6 +53,27 @@ Protocol* SocketCommunicationChannel::receive()
     return message;
 }
 
+bool SocketCommunicationChannel::tryReceive(Protocol* message)
+{
+    ASocket::Socket fd = mainSocket->GetSocketDescriptor();
+    if (fd < 0) return false;
+
+    // Use select() directly with an explicit zero timeval.
+    // SelectSocket(fd, 0) means "no timeout" (blocks forever) per the library API,
+    // so we cannot use it here.
+    fd_set rset;
+    struct timeval tval = {0, 0};
+    FD_ZERO(&rset);
+    FD_SET(fd, &rset);
+
+    int res = select(fd + 1, &rset, nullptr, nullptr, &tval);
+    if (res <= 0 || !FD_ISSET(fd, &rset))
+        return false;
+
+    mainSocket->CTCPClient::Receive((char *)message, sizeof(Protocol));
+    return true;
+}
+
 void SocketCommunicationChannel::sendMain(const Protocol message)
 {
     try {

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.h
@@ -19,6 +19,7 @@ public:
   void handshakeValid();
   void log(int logLevel, const char* data) override;
   Protocol* receive() override;
+  bool tryReceive(Protocol* message) override;
   void sendMain(const Protocol message) override;
   void sendSender(const Protocol message) override;
 

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
@@ -8,69 +8,99 @@
 #include "renode_dpi.h"
 #include "communication/socket_channel.h"
 
-static SocketCommunicationChannel *socketChannel;
+#define MAX_DPI_INSTANCES 8
+static SocketCommunicationChannel *socketChannels[MAX_DPI_INSTANCES] = { nullptr };
 
-bool renodeDPIReceive(uint32_t* actionId, uint64_t* address, uint64_t* value, int32_t* peripheralIndex)
+extern "C" void renodeDPIConnectInst(int id, int receiverPort,
+                                     int senderPort, const char *address)
 {
-    if(!renodeDPIIsConnected())
+    if(id < 0 || id >= MAX_DPI_INSTANCES) return;
+    /* clean up any existing connection */
+    if(socketChannels[id] != nullptr)
     {
-        return false;
+        delete socketChannels[id];
     }
-    Protocol *message = socketChannel->receive();
-    *actionId = message->actionId;
-    *address = message->addr;
-    *value = message->value;
-    *peripheralIndex = message->peripheralIndex;
+    socketChannels[id] = new SocketCommunicationChannel();
+    socketChannels[id]->connect(receiverPort, senderPort, address);
+}
 
-    delete message;
+extern "C" void renodeDPIDisconnectInst(int id)
+{
+    if(id < 0 || id >= MAX_DPI_INSTANCES) return;
+    if(socketChannels[id] != nullptr)
+    {
+        socketChannels[id]->disconnect();
+        delete socketChannels[id];
+        socketChannels[id] = nullptr;
+    }
+}
+
+extern "C" bool renodeDPIIsConnectedInst(int id)
+{
+    if(id < 0 || id >= MAX_DPI_INSTANCES) return false;
+    return socketChannels[id] != nullptr &&
+           socketChannels[id]->isConnected();
+}
+
+extern "C" bool renodeDPIReceiveInst(int id,
+                                     uint32_t *actionId,
+                                     uint64_t *address,
+                                     uint64_t *value,
+                                     int32_t *peripheralIndex)
+{
+    if(!renodeDPIIsConnectedInst(id)) return false;
+    Protocol *msg = socketChannels[id]->receive();
+    *actionId = msg->actionId;
+    *address = msg->addr;
+    *value = msg->value;
+    *peripheralIndex = msg->peripheralIndex;
+    delete msg;
     return true;
 }
 
-void renodeDPIConnect(int receiverPort, int senderPort, const char* address)
+extern "C" bool renodeDPITryReceiveInst(int id,
+                                        uint32_t *actionId,
+                                        uint64_t *address,
+                                        uint64_t *value,
+                                        int32_t *peripheralIndex)
 {
-    socketChannel = new SocketCommunicationChannel();
-    socketChannel->connect(receiverPort, senderPort, address);
-}
-
-void renodeDPIDisconnect()
-{
-    if(socketChannel != NULL)
-    {
-        socketChannel->disconnect();
-    }
-}
-
-bool renodeDPIIsConnected()
-{
-    return socketChannel != NULL && socketChannel->isConnected();
-}
-
-bool renodeDPISend(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex)
-{
-    if(!renodeDPIIsConnected())
-    {
-        return false;
-    }
-    socketChannel->sendMain(Protocol(actionId, address, value, peripheralIndex));
+    if(!renodeDPIIsConnectedInst(id)) return false;
+    Protocol msg;
+    if(!socketChannels[id]->tryReceive(&msg)) return false;
+    *actionId = msg.actionId;
+    *address = msg.addr;
+    *value = msg.value;
+    *peripheralIndex = msg.peripheralIndex;
     return true;
 }
 
-bool renodeDPISendToAsync(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex)
+extern "C" bool renodeDPISendInst(int id,
+                                  uint32_t actionId,
+                                  uint64_t address,
+                                  uint64_t value,
+                                  int32_t peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
-        return false;
-    }
-    socketChannel->sendSender(Protocol(actionId, address, value, peripheralIndex));
+    if(!renodeDPIIsConnectedInst(id)) return false;
+    socketChannels[id]->sendMain(Protocol(actionId, address, value, peripheralIndex));
     return true;
 }
 
-bool renodeDPILog(int logLevel, const char* data)
+extern "C" bool renodeDPISendToAsyncInst(int id,
+                                         uint32_t actionId,
+                                         uint64_t address,
+                                         uint64_t value,
+                                         int32_t peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
-        return false;
-    }
-    socketChannel->log(logLevel, data);
+    if(!renodeDPIIsConnectedInst(id)) return false;
+    socketChannels[id]->sendSender(Protocol(actionId, address, value, peripheralIndex));
+    return true;
+}
+
+extern "C" bool renodeDPILogInst(int id,
+                                 int logLevel,
+                                 const char *data)
+{
+    if(!renodeDPIIsConnectedInst(id)) return false;
+    socketChannels[id]->log(logLevel, data);
     return true;
 }

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.h
@@ -10,13 +10,14 @@
 
 extern "C"
 {
-  void renodeDPIConnect(int receiverPort, int senderPort, const char *address);
-  void renodeDPIDisconnect();
-  bool renodeDPIIsConnected();
-  bool renodeDPIReceive(uint32_t *actionId, uint64_t *address, uint64_t *value, int32_t *peripheralIndex);
-  bool renodeDPISend(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
-  bool renodeDPISendToAsync(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
-  bool renodeDPILog(int logLevel, const char *data);
+  void renodeDPIConnectInst(int id, int receiverPort, int senderPort, const char *address);
+  void renodeDPIDisconnectInst(int id);
+  bool renodeDPIIsConnectedInst(int id);
+  bool renodeDPIReceiveInst(int id, uint32_t *actionId, uint64_t *address, uint64_t *value, int32_t *peripheralIndex);
+  bool renodeDPITryReceiveInst(int id, uint32_t *actionId, uint64_t *address, uint64_t *value, int32_t *peripheralIndex);
+  bool renodeDPISendInst(int id, uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
+  bool renodeDPISendToAsyncInst(int id, uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
+  bool renodeDPILogInst(int id, int logLevel, const char *data);
 }
 
 #endif


### PR DESCRIPTION
## Summary

- **Multi-instance DPI**: Refactors the DPI layer to support up to 8 simultaneous co-simulation connections. All DPI C functions are renamed with an `Inst` suffix and take an `int id` parameter, replacing the previous single global socket channel. The SV package (`renode_pkg`) is updated to match: `renode_connection` and `renode_runtime` carry an `instance_id`, and a `connect_automatic()` helper is added alongside the existing `connect_plus_args()`.

- **Non-blocking receive**: Adds `tryReceive()` to the socket channel using `select()` with zero timeout, exposed as `renodeDPITryReceiveInst` in the DPI layer and `try_receive()` in SV. Used internally by the IRQ preemption mechanism below.

- **IRQ preemption of `sync_time`**: When an input signal changes mid-tick (interrupt arrives), `renode_inputs` sets `interrupt_preempt_requested` on the runtime. `sync_time` detects this on the next clock edge, sends an early partial `TickClock` ack with the actual elapsed tick count, and exits — allowing Renode to process the interrupt immediately rather than waiting for the full tick window to expire.

All changes have been validated against hardware.