### PR TITLE
Fix non-IMapped executable memory deadlock (#877)

### DIFF
--- a/tests/unit-tests/non-mapped-executable/ExecutableByteMemory.cs
+++ b/tests/unit-tests/non-mapped-executable/ExecutableByteMemory.cs
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2010-2026 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Memory
+{
+    // A simple byte-addressable memory peripheral that does NOT implement IMapped.
+    // This simulates dynamically compiled C# peripherals that act as executable memory
+    // but go through I/O callbacks for all accesses.
+    public class ExecutableByteMemory : IBytePeripheral, IWordPeripheral, IDoubleWordPeripheral, IKnownSize
+    {
+        public ExecutableByteMemory(int size)
+        {
+            this.size = size;
+            data = new byte[size];
+        }
+
+        public byte ReadByte(long offset)
+        {
+            return data[offset];
+        }
+
+        public void WriteByte(long offset, byte value)
+        {
+            data[offset] = value;
+        }
+
+        public ushort ReadWord(long offset)
+        {
+            return (ushort)(data[offset] | (data[offset + 1] << 8));
+        }
+
+        public void WriteWord(long offset, ushort value)
+        {
+            data[offset] = (byte)value;
+            data[offset + 1] = (byte)(value >> 8);
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            return (uint)(data[offset] | (data[offset + 1] << 8) |
+                          (data[offset + 2] << 16) | (data[offset + 3] << 24));
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            data[offset] = (byte)value;
+            data[offset + 1] = (byte)(value >> 8);
+            data[offset + 2] = (byte)(value >> 16);
+            data[offset + 3] = (byte)(value >> 24);
+        }
+
+        public void Reset()
+        {
+            for(int i = 0; i < data.Length; i++)
+            {
+                data[i] = 0;
+            }
+        }
+
+        public long Size { get { return size; } }
+
+        private readonly int size;
+        private readonly byte[] data;
+    }
+}

--- a/tests/unit-tests/non-mapped-executable/non-mapped-executable.robot
+++ b/tests/unit-tests/non-mapped-executable/non-mapped-executable.robot
@@ -1,0 +1,39 @@
+*** Variables ***
+# ARM Thumb "b ." (branch to self) = 0xE7FE
+${THUMB_LOOP}=          0xE7FE
+
+*** Keywords ***
+Create Machine With Array Memory
+    Execute Command         mach create
+    Execute Command         machine LoadPlatformDescription @${CURDIR}/platform_array.repl
+    Create Log Tester       0
+
+Create Machine With Non Mapped Executable Memory
+    Execute Command         mach create
+    Execute Command         include @${CURDIR}/ExecutableByteMemory.cs
+    Execute Command         machine LoadPlatformDescription @${CURDIR}/platform_custom.repl
+    Create Log Tester       0
+
+Setup CPU And Write Loop
+    # Write ARM Thumb "b ." (branch to self) at 0x20000000
+    Execute Command         sysbus WriteWord 0x20000000 ${THUMB_LOOP}
+    Execute Command         cpu PC 0x20000000
+
+*** Test Cases ***
+Should Execute Code From ArrayMemory
+    [Documentation]         Control test: ArrayMemory (non-IMapped, built-in) should
+    ...                     already support instruction fetch via IO_MEM_EXECUTABLE_IO.
+    [Timeout]               60 seconds
+    Create Machine With Array Memory
+    Setup CPU And Write Loop
+    Execute Command         emulation RunFor "0.0001"
+    Should Not Be In Log    CPU abort
+
+Should Execute Code From Non IMapped Peripheral
+    [Documentation]         Reproduces Renode bug #877: RunFor aborts when
+    ...                     instruction fetches hit a non-IMapped C# peripheral.
+    [Timeout]               60 seconds
+    Create Machine With Non Mapped Executable Memory
+    Setup CPU And Write Loop
+    Execute Command         emulation RunFor "0.0001"
+    Should Not Be In Log    CPU abort

--- a/tests/unit-tests/non-mapped-executable/platform_array.repl
+++ b/tests/unit-tests/non-mapped-executable/platform_array.repl
@@ -1,0 +1,12 @@
+ram: Memory.MappedMemory @ sysbus 0x0
+    size: 0x10000
+
+exec_mem: Memory.ArrayMemory @ sysbus 0x20000000
+    size: 0x1000
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m0"
+    nvic: nvic

--- a/tests/unit-tests/non-mapped-executable/platform_custom.repl
+++ b/tests/unit-tests/non-mapped-executable/platform_custom.repl
@@ -1,0 +1,12 @@
+ram: Memory.MappedMemory @ sysbus 0x0
+    size: 0x10000
+
+exec_mem: Memory.ExecutableByteMemory @ sysbus 0x20000000
+    size: 0x1000
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m0"
+    nvic: nvic


### PR DESCRIPTION
### Related issue

Fixes #877
Requires renode/renode-infrastructure#186

### Description

Fixes a deadlock in `emulation RunFor` when instruction fetches hit dynamically compiled C# peripherals that don't implement `IMapped`.

The actual code fix is in the infrastructure submodule (renode-infrastructure#186 — adds `IMapped` check in `TranslationCPU.UpdatePageAccess`). This PR updates the submodule pointer to bring that fix in, and adds a regression test.

Two robot test cases:
- ArrayMemory control (instruction fetch from built-in non-IMapped peripheral — passes)
- ExecutableByteMemory (instruction fetch from dynamically compiled non-IMapped peripheral — fails without the infrastructure fix)

### Usage example

Run with: `renode-test tests/unit-tests/non-mapped-executable/non-mapped-executable.robot`