### PR TITLE
[#918] packaging: fix gtk-update-icon-cache warning

### DIFF
--- a/tools/packaging/linux/update_icon_cache.sh
+++ b/tools/packaging/linux/update_icon_cache.sh
@@ -1,2 +1,2 @@
-touch --no-create /usr/share/applications/icons/hicolor &>/dev/null || true
-gtk-update-icon-cache /usr/share/applications/icons/hicolor &>/dev/null || true
+touch --no-create /usr/share/icons/hicolor &>/dev/null || true
+gtk-update-icon-cache /usr/share/icons/hicolor &>/dev/null || true


### PR DESCRIPTION
### Related issue

closes #918 

### Description

This PR fixes gtk-update-icon-cache warning make_linux_package.sh copies icons to /usr/share/icons/hicolor, while update_icon_cache tries to update them in a different location. This PR fixes the location to remove the following warning:
   `gtk-update-icon-cache: No theme index file.`

### Usage example

1. Checkout this branch or cherry-pick the commit, rebuild the package, install it -> no more warning
```sh
./build.sh -p
cd output/packages/
output/packages$ sudo dpkg -i renode_1.16.1_amd64.deb 
Selecting previously unselected package renode.
(Reading database ... 225404 files and directories currently installed.)
Preparing to unpack renode_1.16.1_amd64.deb ...
Unpacking renode (1.16.1) ...
Setting up renode (1.16.1) ...
Processing triggers for hicolor-icon-theme (0.17-2) ...
gtk-update-icon-cache: Cache file created successfully.
```

### Additional information

None