### PR TITLE
Add Realtek RTS5817 MAA EVB support

### DIFF
--- a/platforms/cpus/realtek_rts5817.repl
+++ b/platforms/cpus/realtek_rts5817.repl
@@ -1,0 +1,43 @@
+flash: Memory.MappedMemory @ sysbus 0x1800000
+    size: 0x00200000
+
+sram: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x00040000
+
+qspi: SPI.RTS5817_QuadSPI @ sysbus 0x40000000
+
+spiFlash: SPI.GenericSpiFlash @ qspi
+    underlyingMemory: flash
+    manufacturerId: 0xC8
+    memoryType: 0x40
+
+spi0: SPI.RTS5817_SPI @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40002000; size: 0x100; region: "ctrl" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40003000; size: 0x100; region: "dw" }
+    }
+    -> nvic@4
+
+spi1: SPI.RTS5817_SPI @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40004000; size: 0x100; region: "ctrl" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40004200; size: 0x100; region: "dw" }
+    }
+    -> nvic@5
+
+sensor: Sensors.RTS_MAASensor @ spi0
+
+uart0: UART.NS16550 @ sysbus 0x40120000
+    wideRegisters: true
+    -> nvic@15
+
+uart1: UART.NS16550 @ sysbus 0x40128000
+    wideRegisters: true
+    -> nvic@16
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    priorityMask: 0xF0
+    systickFrequency: 240000000
+    IRQ -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m33"
+    nvic: nvic

--- a/scripts/single-node/realtek_rts5817_zephyr.resc
+++ b/scripts/single-node/realtek_rts5817_zephyr.resc
@@ -1,0 +1,20 @@
+:name: Realtek RTS5817 MAA
+:description: This script runs zephyr on RTS5817 MAA EVB
+
+$name?="Realtek RTS5817"
+
+$bin?=@https://zephyr-dashboard.renode.io/zephyr/7edd8834f66701189dfaf3f1142b2bfba0b508bd/rts5817_maa_evb/hello_world/hello_world.elf
+
+using sysbus
+mach create $name
+
+machine LoadPlatformDescription @platforms/cpus/realtek_rts5817.repl
+
+showAnalyzer uart0
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+
+runMacro $reset


### PR DESCRIPTION
### Related issue

Please provide the number of the issue that is addressed by this PR in the #number format.

### Description

This commit add a new platform definition for Realtek RTS5817 MAA EVB and a sample test script.

### Usage example

In renode monitor
```bash
start @scripts/single-node/realtek_rts5817_zephyr.resc
```

### Additional information

This PR depends on the following three PRs:
https://github.com/renode/renode-infrastructure/pull/208
https://github.com/renode/renode-infrastructure/pull/209
https://github.com/renode/renode-infrastructure/pull/210
