### PR TITLE
Enhance DPI integration with non-blocking connections and fixes

### DIFF
--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/modules/renode.sv
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/modules/renode.sv
@@ -87,6 +87,17 @@ module renode #(
 
     // This task doesn't block elapse of a simulation time, when messages are being received and handled in an other place.
     if (runtime.connection.exclusive_receive.try_get() != 0) begin
+      did_receive = runtime.connection.receive(message);
+      runtime.connection.exclusive_receive.put();
+      if (did_receive) handle_message(message);
+    end
+  endtask
+
+  task static try_receive_and_handle_message(output bit did_receive);
+    message_t message;
+
+    // This task doesn't block elapse of a simulation time, when messages are being received and handled in an other place.
+    if (runtime.connection.exclusive_receive.try_get() != 0) begin
       did_receive = runtime.connection.try_receive(message);
       runtime.connection.exclusive_receive.put();
       if (did_receive) handle_message(message);
@@ -190,18 +201,18 @@ module renode #(
     message.data = 0;
 
     runtime.connection.exclusive_receive.get();
-    if(!runtime.connection.is_connected()) begin
+    if(!runtime.is_connected()) begin
         runtime.connection.exclusive_receive.put();
         return;
     end
 
     runtime.connection.send_to_async_receiver(message);
 
-    runtime.connection.receive(message);
+    runtime.connection.receive_or_fail(message);
     while (message.action != renode_pkg::writeRequest) begin
       handle_message(message);
       if(message.action == renode_pkg::disconnect) break;
-      runtime.connection.receive(message);
+      runtime.connection.receive_or_fail(message);
     end
 
     runtime.connection.exclusive_receive.put();
@@ -226,17 +237,17 @@ module renode #(
     message.data = runtime.peripherals[peripheral_index].write_transaction_data;
 
     runtime.connection.exclusive_receive.get();
-    if(!runtime.connection.is_connected()) begin
+    if (!runtime.is_connected()) begin
         runtime.connection.exclusive_receive.put();
         return;
     end
 
     runtime.connection.send_to_async_receiver(message);
-    runtime.connection.receive(message);
+    runtime.connection.receive_or_fail(message);
     while (message.action != renode_pkg::pushConfirmation) begin
       handle_message(message);
       if(message.action == renode_pkg::disconnect) break;
-      runtime.connection.receive(message);
+      runtime.connection.receive_or_fail(message);
     end
 
     runtime.connection.exclusive_receive.put();

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
@@ -108,7 +108,6 @@ package renode_pkg;
     endfunction
 
   task connect(int receiver_port, int sender_port, string address);
-    // Backgorund connect, check is_connected from a clock-driven block
     renodeDPIConnect(receiver_port, sender_port, address);
     $display("Renode at %t: Renode connection requested (background)...", $realtime);
   endtask

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
@@ -107,13 +107,11 @@ package renode_pkg;
       $timeformat(0, 9, "s", 0);
     endfunction
 
-    function void connect(int receiver_port, int sender_port, string address);
-      renodeDPIConnect(receiver_port, sender_port, address);
-      if(is_connected())
-        $display("Renode at %t: Connected using the socket based interface", $realtime);
-      else
-        $error("Renode at %t: Connection error", $realtime);
-    endfunction
+  task connect(int receiver_port, int sender_port, string address);
+    // Backgorund connect, check is_connected from a clock-driven block
+    renodeDPIConnect(receiver_port, sender_port, address);
+    $display("Renode at %t: Renode connection requested (background)...", $realtime);
+  endtask
 
     function bit is_connected();
       return renodeDPIIsConnected();
@@ -285,19 +283,21 @@ package renode_pkg;
       end
     endfunction
 
-    function void connect_plus_args();
-      int receiver_port, sender_port;
-      string address;
-      if(!$value$plusargs({ReceiverPortArgName, "=%d"}, receiver_port)
-        || !$value$plusargs({SenderPortArgName, "=%d"}, sender_port)
-        || !$value$plusargs({AddressArgName, "=%s"}, address))
-      begin
-          $error("Please specify the +%s, +%s and +%s arguments in the command that invokes the simulation", ReceiverPortArgName, SenderPortArgName, AddressArgName);
-      end
-      else begin
-        connection.connect(receiver_port, sender_port, address);
-      end
-    endfunction
+  task connect_plus_args();
+    int receiver_port, sender_port;
+    string address;
+    if(
+      !$value$plusargs({ReceiverPortArgName, "=%d"}, receiver_port) ||
+      !$value$plusargs({SenderPortArgName, "=%d"}, sender_port) ||
+      !$value$plusargs({AddressArgName, "=%s"}, address)
+    ) begin
+      $error("Please specify the +%s, +%s and +%s arguments in the command that invokes the simulation",
+            ReceiverPortArgName, SenderPortArgName, AddressArgName);
+    end
+    else begin
+      connection.connect(receiver_port, sender_port, address);
+    end
+  endtask
 
     function bit is_connected();
       return connection.is_connected();

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/hdl/renode_pkg.sv
@@ -41,15 +41,33 @@ package renode_pkg;
     LogError = 3
   } log_level_e;
 
+  // Keep in sync with definition in renode_dpi.cpp
+  typedef enum int {
+    Unconnected = 0,
+    NeedsReconnection = 1,
+    Connecting = 2,
+    Connected = 3,
+    Disconnected = 4,  // Indicate graceful disconnection
+    Error = 5  // Error while connecting
+  } connnection_status_e;
+
   import "DPI-C" function void renodeDPIConnect(
-    int receiverPort,
-    int senderPort,
-    string address
+    int unsigned receiverPort,
+    int unsigned senderPort,
+    string address,
+    int unsigned timeoutMs
+  );
+
+  import "DPI-C" function void renodeDPIConnectInBackground(
+    int unsigned receiverPort,
+    int unsigned senderPort,
+    string address,
+    int unsigned timeoutMs
   );
 
   import "DPI-C" function void renodeDPIDisconnect();
 
-  import "DPI-C" function bit renodeDPIIsConnected();
+  import "DPI-C" function int renodeDPIGetConnectionStatus();
 
   import "DPI-C" function bit renodeDPILog(
     int logLevel,
@@ -60,7 +78,14 @@ package renode_pkg;
     output action_e action,
     output address_t address,
     output data_t data,
-    output int peripheralIndex 
+    output int peripheralIndex
+  );
+
+  import "DPI-C" function bit renodeDPITryReceive(
+    output action_e action,
+    output address_t address,
+    output data_t data,
+    output int peripheralIndex
   );
 
   import "DPI-C" function bit renodeDPISend(
@@ -107,16 +132,16 @@ package renode_pkg;
       $timeformat(0, 9, "s", 0);
     endfunction
 
-    function void connect(int receiver_port, int sender_port, string address);
-      renodeDPIConnect(receiver_port, sender_port, address);
-      if(is_connected())
-        $display("Renode at %t: Connected using the socket based interface", $realtime);
-      else
-        $error("Renode at %t: Connection error", $realtime);
-    endfunction
+    task connect(int unsigned receiver_port, int unsigned sender_port, string address, int unsigned timeout_ms = 10000);
+      renodeDPIConnect(receiver_port, sender_port, address, timeout_ms);
+    endtask
 
-    function bit is_connected();
-      return renodeDPIIsConnected();
+    task connect_in_background(int unsigned receiver_port, int unsigned sender_port, string address, int unsigned timeout_ms = 10000);
+      renodeDPIConnectInBackground(receiver_port, sender_port, address, timeout_ms);
+    endtask
+
+    function connnection_status_e get_connection_status();
+      return connnection_status_e'(renodeDPIGetConnectionStatus());
     endfunction
 
     function void fatal_error(string message);
@@ -146,14 +171,34 @@ package renode_pkg;
       end
     endfunction
 
-    function void receive(output message_t message);
-      bit is_received = try_receive(message);
+    function bit receive(output message_t message);
+      bit is_received = renodeDPIReceive(
+          message.action, message.address, message.data, message.peripheral_index
+      );
+      if (is_received) begin
+`ifdef RENODE_DEBUG
+        log(LogDebug, $sformatf(
+            "Received action %0s, address = 'h%h, data = 'h%h, peripheral index: %d",
+            message.action.name(),
+            message.address,
+            message.data,
+            message.peripheral_index
+            ));
+`endif
+      end
+      return is_received;
+    endfunction
+
+    function void receive_or_fail(output message_t message);
+      bit is_received = receive(message);
       if (!is_received) fatal_error("Unable to receive a message.");
     endfunction
 
     function bit try_receive(output message_t message);
-      bit is_received = renodeDPIReceive(message.action, message.address, message.data, message.peripheral_index);
-      if(is_received) begin
+      bit is_received = renodeDPITryReceive(
+          message.action, message.address, message.data, message.peripheral_index
+      );
+      if (is_received) begin
 `ifdef RENODE_DEBUG
       log(LogDebug, $sformatf("Received action %0s, address = 'h%h, data = 'h%h, peripheral index: %d", message.action.name(), message.address, message.data, message.peripheral_index));
 `endif
@@ -285,22 +330,53 @@ package renode_pkg;
       end
     endfunction
 
-    function void connect_plus_args();
-      int receiver_port, sender_port;
-      string address;
-      if(!$value$plusargs({ReceiverPortArgName, "=%d"}, receiver_port)
-        || !$value$plusargs({SenderPortArgName, "=%d"}, sender_port)
-        || !$value$plusargs({AddressArgName, "=%s"}, address))
-      begin
-          $error("Please specify the +%s, +%s and +%s arguments in the command that invokes the simulation", ReceiverPortArgName, SenderPortArgName, AddressArgName);
+    function get_connection_plus_args(output int receiver_port, output int sender_port, output string address);
+      if (!$value$plusargs(
+              {ReceiverPortArgName, "=%d"}, receiver_port
+          ) || !$value$plusargs(
+              {SenderPortArgName, "=%d"}, sender_port
+          ) || !$value$plusargs(
+              {AddressArgName, "=%s"}, address
+          )) begin
+        $error(
+            "Please specify the +%s, +%s and +%s arguments in the command that invokes the simulation",
+            ReceiverPortArgName, SenderPortArgName, AddressArgName);
+        return 0;
       end
-      else begin
-        connection.connect(receiver_port, sender_port, address);
-      end
+
+      return 1;
     endfunction
 
+    task connect_plus_args();
+      int receiver_port, sender_port;
+      string address;
+      if (get_connection_plus_args(receiver_port, sender_port, address)) begin
+        connection.connect(receiver_port, sender_port, address);
+        $display("Renode at %t: Connection status after connect: %s", $realtime, connection.get_connection_status().name());
+      end
+    endtask
+
+    task connect_plus_args_in_background();
+      int receiver_port, sender_port;
+      string address;
+      connnection_status_e status = connection.get_connection_status();
+
+      if (get_connection_plus_args(receiver_port, sender_port, address)) begin
+        connection.connect_in_background(receiver_port, sender_port, address);
+        if (status == Unconnected) begin
+          $display("Renode at %t: Renode connection requested (background)...", $realtime);
+        end
+      end
+    endtask
+
     function bit is_connected();
-      return connection.is_connected();
+      return connection.get_connection_status() == Connected;
+    endfunction
+
+    function bit has_lost_connection();
+      connnection_status_e status = connection.get_connection_status();
+
+      return status == Disconnected || status == Error;
     endfunction
   endclass
 endpackage

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/libs/socket-cpp/Socket/TCPClient.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/libs/socket-cpp/Socket/TCPClient.cpp
@@ -27,8 +27,7 @@ bool CTCPClient::SetRcvTimeout(unsigned int msec_timeout) {
 #else
     int iErr;
 
-    // it's expecting an int but it doesn't matter...
-    iErr = setsockopt(m_ConnectSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&msec_timeout, sizeof(struct timeval));
+    iErr = setsockopt(m_ConnectSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&msec_timeout, sizeof(msec_timeout));
     if (iErr < 0) {
         if (m_eSettingsFlags & ENABLE_LOG)
             m_oLog("[TCPServer][Error] CTCPClient::SetRcvTimeout : Socket error in SO_RCVTIMEO call to setsockopt.");
@@ -65,8 +64,7 @@ bool CTCPClient::SetSndTimeout(unsigned int msec_timeout) {
 #else
     int iErr;
 
-    // it's expecting an int but it doesn't matter...
-    iErr = setsockopt(m_ConnectSocket, SOL_SOCKET, SO_SNDTIMEO, (char*)&msec_timeout, sizeof(struct timeval));
+    iErr = setsockopt(m_ConnectSocket, SOL_SOCKET, SO_SNDTIMEO, (char*)&msec_timeout, sizeof(msec_timeout));
     if (iErr < 0) {
         if (m_eSettingsFlags & ENABLE_LOG)
             m_oLog("[TCPServer][Error] CTCPClient::SetSndTimeout : Socket error in SO_SNDTIMEO call to setsockopt.");

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
@@ -7,6 +7,12 @@
 
 #include "socket_channel.h"
 
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/ioctl.h>
+#endif
+
 SocketCommunicationChannel::SocketCommunicationChannel()
     : connected(false)
 {
@@ -71,6 +77,33 @@ Protocol* SocketCommunicationChannel::receive()
         return nullptr;
     }
 
+    return message;
+}
+
+Protocol* SocketCommunicationChannel::tryReceive()
+{
+#ifdef _WIN32
+    u_long available = 0;
+    if (ioctlsocket(mainSocket->GetSocketDescriptor(), FIONREAD, &available) != 0) {
+        return nullptr;
+    }
+#else
+    int available = 0;
+    if (ioctl(mainSocket->GetSocketDescriptor(), FIONREAD, &available) != 0) {
+        return nullptr;
+    }
+#endif
+
+    if (available < (int)sizeof(Protocol)) {
+        return nullptr;
+    }
+
+    Protocol* message = new Protocol;
+    int ret = mainSocket->CTCPClient::Receive((char *)message, sizeof(Protocol), true);
+    if (ret <= 0) {
+        delete message;
+        return nullptr;
+    }
     return message;
 }
 

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
@@ -23,14 +23,40 @@ SocketCommunicationChannel::SocketCommunicationChannel()
 
 void SocketCommunicationChannel::connect(int receiverPort, int senderPort, const char* address)
 {
-    bool mainOk = mainSocket->Connect(address, std::to_string(receiverPort));
-    bool senderOk = senderSocket->Connect(address, std::to_string(senderPort));
-    if (!mainOk || !senderOk) {
+    if (!mainSocket->Connect(address, std::to_string(receiverPort))) {
         return;
     }
-    mainSocket->SetRcvTimeout(2000);
-    senderSocket->SetRcvTimeout(2000);
+
+    // To handle the partial-connect race we hold mainSocket
+    // open and retry senderSocket briefly before giving up.
+    bool senderOk = false;
+    for (int i = 0; i < 20; ++i) {
+        if (senderSocket->Connect(address, std::to_string(senderPort))) {
+            senderOk = true;
+            break;
+        }
+#ifdef _WIN32
+        Sleep(50);
+#else
+        usleep(50000);
+#endif
+    }
+
+    if (!senderOk) {
+        mainSocket->Disconnect();
+        return;
+    }
+    mainSocket->SetRcvTimeout(60000);
+    senderSocket->SetRcvTimeout(60000);
     handshakeValid();
+
+    if (connected) {
+        // Once the handshake is done, drop back to a normal timeout so
+        // request/response paths (read_transaction, write_transaction) fail
+        // promptly if Renode goes away mid-operation.
+        mainSocket->SetRcvTimeout(5000);
+        senderSocket->SetRcvTimeout(5000);
+    }
 }
 
 void SocketCommunicationChannel::disconnect()

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
@@ -8,6 +8,7 @@
 #include "socket_channel.h"
 
 SocketCommunicationChannel::SocketCommunicationChannel()
+    : connected(false)
 {
     ASocket::SettingsFlag dontLog = ASocket::NO_FLAGS;
     mainSocket.reset(new CTCPClient(NULL, dontLog));
@@ -16,8 +17,13 @@ SocketCommunicationChannel::SocketCommunicationChannel()
 
 void SocketCommunicationChannel::connect(int receiverPort, int senderPort, const char* address)
 {
-    mainSocket->Connect(address, std::to_string(receiverPort));
-    senderSocket->Connect(address, std::to_string(senderPort));
+    bool mainOk = mainSocket->Connect(address, std::to_string(receiverPort));
+    bool senderOk = senderSocket->Connect(address, std::to_string(senderPort));
+    if (!mainOk || !senderOk) {
+        return;
+    }
+    mainSocket->SetRcvTimeout(2000);
+    senderSocket->SetRcvTimeout(2000);
     handshakeValid();
 }
 
@@ -34,10 +40,19 @@ bool SocketCommunicationChannel::isConnected()
 void SocketCommunicationChannel::handshakeValid()
 {
     Protocol* received = receive();
-    if(received->actionId == handshake) {
+    if (received == nullptr) {
+        mainSocket->Disconnect();
+        senderSocket->Disconnect();
+        return;
+    }
+    if (received->actionId == handshake) {
         sendMain(Protocol(handshake, 0, 0, noPeripheralIndex));
         connected = true;
+    } else {
+        mainSocket->Disconnect();
+        senderSocket->Disconnect();
     }
+    delete received;
 }
 
 void SocketCommunicationChannel::log(int logLevel, const char* data)
@@ -49,7 +64,13 @@ void SocketCommunicationChannel::log(int logLevel, const char* data)
 Protocol* SocketCommunicationChannel::receive()
 {
     Protocol* message = new Protocol;
-    mainSocket->CTCPClient::Receive((char *)message,  sizeof(Protocol));
+    int ret = mainSocket->CTCPClient::Receive((char *)message, sizeof(Protocol), true);
+
+    if(ret <= 0) {
+        delete message;
+        return nullptr;
+    }
+
     return message;
 }
 

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
@@ -7,6 +7,12 @@
 
 #include "socket_channel.h"
 
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/ioctl.h>
+#endif
+
 SocketCommunicationChannel::SocketCommunicationChannel()
     : connected(false)
 {
@@ -65,6 +71,33 @@ Protocol* SocketCommunicationChannel::receive()
         return nullptr;
     }
 
+    return message;
+}
+
+Protocol* SocketCommunicationChannel::tryReceive()
+{
+#ifdef _WIN32
+    u_long available = 0;
+    if (ioctlsocket(mainSocket->GetSocketDescriptor(), FIONREAD, &available) != 0) {
+        return nullptr;
+    }
+#else
+    int available = 0;
+    if (ioctl(mainSocket->GetSocketDescriptor(), FIONREAD, &available) != 0) {
+        return nullptr;
+    }
+#endif
+
+    if (available < (int)sizeof(Protocol)) {
+        return nullptr;
+    }
+
+    Protocol* message = new Protocol;
+    int ret = mainSocket->CTCPClient::Receive((char *)message, sizeof(Protocol), true);
+    if (ret <= 0) {
+        delete message;
+        return nullptr;
+    }
     return message;
 }
 

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
@@ -8,6 +8,7 @@
 #include "socket_channel.h"
 
 SocketCommunicationChannel::SocketCommunicationChannel()
+    : connected(false)
 {
     ASocket::SettingsFlag dontLog = ASocket::NO_FLAGS;
     mainSocket.reset(new CTCPClient(NULL, dontLog));
@@ -23,7 +24,8 @@ void SocketCommunicationChannel::connect(int receiverPort, int senderPort, const
 
 void SocketCommunicationChannel::disconnect()
 {
-    connected = false;
+    mainSocket->Disconnect();
+    senderSocket->Disconnect();
 }
 
 bool SocketCommunicationChannel::isConnected()
@@ -34,10 +36,17 @@ bool SocketCommunicationChannel::isConnected()
 void SocketCommunicationChannel::handshakeValid()
 {
     Protocol* received = receive();
-    if(received->actionId == handshake) {
+    if (received == nullptr) {
+        disconnect();
+        return;
+    }
+    if (received->actionId == handshake) {
         sendMain(Protocol(handshake, 0, 0, noPeripheralIndex));
         connected = true;
+    } else {
+        disconnect();
     }
+    delete received;
 }
 
 void SocketCommunicationChannel::log(int logLevel, const char* data)
@@ -49,7 +58,13 @@ void SocketCommunicationChannel::log(int logLevel, const char* data)
 Protocol* SocketCommunicationChannel::receive()
 {
     Protocol* message = new Protocol;
-    mainSocket->CTCPClient::Receive((char *)message,  sizeof(Protocol));
+    int ret = mainSocket->CTCPClient::Receive((char *)message, sizeof(Protocol), true);
+
+    if(ret <= 0) {
+        delete message;
+        return nullptr;
+    }
+
     return message;
 }
 

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.cpp
@@ -21,11 +21,32 @@ SocketCommunicationChannel::SocketCommunicationChannel()
     senderSocket.reset(new CTCPClient(NULL, dontLog));
 }
 
-void SocketCommunicationChannel::connect(int receiverPort, int senderPort, const char* address)
+void SocketCommunicationChannel::connect(SocketConnectionArgs *args)
 {
-    mainSocket->Connect(address, std::to_string(receiverPort));
-    senderSocket->Connect(address, std::to_string(senderPort));
+    if (!mainSocket->Connect(args->address, std::to_string(args->receiverPort))) {
+        return;
+    }
+
+    // To handle the partial-connect race we hold mainSocket
+    // open and retry senderSocket briefly before giving up.
+    const int senderRetryDelayMs = 10;
+    while(true) {
+        if (senderSocket->Connect(args->address, std::to_string(args->senderPort))) {
+            break;
+        }
+#ifdef _WIN32
+        Sleep(senderRetryDelayMs);
+#else
+        usleep(senderRetryDelayMs * 1000);
+#endif
+    }
+
+    mainSocket->SetRcvTimeout(args->handshakeTimeout);
+    senderSocket->SetRcvTimeout(args->handshakeTimeout);
     handshakeValid();
+
+    mainSocket->SetRcvTimeout(0);
+    senderSocket->SetRcvTimeout(0);
 }
 
 void SocketCommunicationChannel::disconnect()

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.h
@@ -19,6 +19,7 @@ public:
   void handshakeValid();
   void log(int logLevel, const char* data) override;
   Protocol* receive() override;
+  Protocol* tryReceive();
   void sendMain(const Protocol message) override;
   void sendSender(const Protocol message) override;
 

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/communication/socket_channel.h
@@ -9,11 +9,18 @@
 #include "communication_channel.h"
 #include "../../libs/socket-cpp/Socket/TCPClient.h"
 
+struct SocketConnectionArgs {
+    int receiverPort;
+    int senderPort;
+    std::string address;
+    unsigned int handshakeTimeout;
+};
+
 class SocketCommunicationChannel : public CommunicationChannel
 {
 public:
   SocketCommunicationChannel();
-  void connect(int receiverPort, int senderPort, const char* address);
+  void connect(SocketConnectionArgs *args);
   void disconnect();
   bool isConnected() override;
   void handshakeValid();

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
@@ -152,7 +152,7 @@ bool renodeDPIReceive(uint32_t* actionId, uint64_t* address, uint64_t* value, in
         return false;
     }
 
-    Protocol *message = ch->receive();
+    Protocol *message = ch->tryReceive();
     if (message == nullptr) {
         return false;
     }

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
@@ -8,15 +8,155 @@
 #include "renode_dpi.h"
 #include "communication/socket_channel.h"
 
-static SocketCommunicationChannel *socketChannel;
+#include <atomic>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <process.h>
+#else
+#include <pthread.h>
+#include <unistd.h>
+#endif
+
+static std::atomic<SocketCommunicationChannel*> socketChannel{nullptr};
+static std::atomic<bool> connectThreadRunning{false};
+static std::atomic<bool> shouldStopConnect{false};
+
+#ifdef _WIN32
+static HANDLE connectThreadHandle = NULL;
+#else
+static pthread_t connectThreadHandle;
+static bool connectThreadJoinable = false;
+#endif
+
+struct ConnectArgs {
+    int receiverPort;
+    int senderPort;
+    std::string address;
+};
+
+static void platformSleepMs(unsigned int ms)
+{
+#ifdef _WIN32
+    Sleep(ms);
+#else
+    usleep(ms * 1000);
+#endif
+}
+
+static void connectLoopBody(ConnectArgs* args)
+{
+    while (!shouldStopConnect.load()) {
+        SocketCommunicationChannel* candidate = new SocketCommunicationChannel();
+        candidate->connect(args->receiverPort, args->senderPort, args->address.c_str());
+
+        if (candidate->isConnected()) {
+            socketChannel.store(candidate, std::memory_order_release);
+            break;
+        }
+
+        delete candidate;
+        platformSleepMs(100);
+    }
+    connectThreadRunning.store(false);
+    delete args;
+}
+
+#ifdef _WIN32
+static unsigned __stdcall connectThreadEntry(void* arg)
+{
+    connectLoopBody(static_cast<ConnectArgs*>(arg));
+    return 0;
+}
+#else
+static void* connectThreadEntry(void* arg)
+{
+    connectLoopBody(static_cast<ConnectArgs*>(arg));
+    return nullptr;
+}
+#endif
+
+static void joinConnectThread()
+{
+#ifdef _WIN32
+    if (connectThreadHandle != NULL) {
+        WaitForSingleObject(connectThreadHandle, INFINITE);
+        CloseHandle(connectThreadHandle);
+        connectThreadHandle = NULL;
+    }
+#else
+    if (connectThreadJoinable) {
+        pthread_join(connectThreadHandle, nullptr);
+        connectThreadJoinable = false;
+    }
+#endif
+}
+
+void renodeDPIConnect(int receiverPort, int senderPort, const char* address)
+{
+    if (renodeDPIIsConnected()) return;
+
+    bool expected = false;
+    if (!connectThreadRunning.compare_exchange_strong(expected, true)) {
+        // A previous connect thread is still in flight; don't spawn another.
+        return;
+    }
+
+    joinConnectThread();
+
+    ConnectArgs* args = new ConnectArgs;
+    args->receiverPort = receiverPort;
+    args->senderPort = senderPort;
+    args->address = address;
+
+    shouldStopConnect.store(false);
+
+#ifdef _WIN32
+    connectThreadHandle = (HANDLE)_beginthreadex(
+        NULL, 0, connectThreadEntry, args, 0, NULL);
+    if (connectThreadHandle == NULL) {
+        delete args;
+        connectThreadRunning.store(false);
+    }
+#else
+    if (pthread_create(&connectThreadHandle, nullptr, connectThreadEntry, args) == 0) {
+        connectThreadJoinable = true;
+    } else {
+        delete args;
+        connectThreadRunning.store(false);
+    }
+#endif
+}
+
+void renodeDPIDisconnect()
+{
+    shouldStopConnect.store(true);
+    joinConnectThread();
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    if (ch != nullptr) {
+        ch->disconnect();
+    }
+}
+
+bool renodeDPIIsConnected()
+{
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    return ch != nullptr && ch->isConnected();
+}
 
 bool renodeDPIReceive(uint32_t* actionId, uint64_t* address, uint64_t* value, int32_t* peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    if (ch == nullptr || !ch->isConnected()) {
         return false;
     }
-    Protocol *message = socketChannel->receive();
+
+    Protocol *message = ch->receive();
+    if (message == nullptr) {
+        return false;
+    }
+
     *actionId = message->actionId;
     *address = message->addr;
     *value = message->value;
@@ -26,51 +166,32 @@ bool renodeDPIReceive(uint32_t* actionId, uint64_t* address, uint64_t* value, in
     return true;
 }
 
-void renodeDPIConnect(int receiverPort, int senderPort, const char* address)
-{
-    socketChannel = new SocketCommunicationChannel();
-    socketChannel->connect(receiverPort, senderPort, address);
-}
-
-void renodeDPIDisconnect()
-{
-    if(socketChannel != NULL)
-    {
-        socketChannel->disconnect();
-    }
-}
-
-bool renodeDPIIsConnected()
-{
-    return socketChannel != NULL && socketChannel->isConnected();
-}
-
 bool renodeDPISend(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    if (ch == nullptr || !ch->isConnected()) {
         return false;
     }
-    socketChannel->sendMain(Protocol(actionId, address, value, peripheralIndex));
+    ch->sendMain(Protocol(actionId, address, value, peripheralIndex));
     return true;
 }
 
 bool renodeDPISendToAsync(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    if (ch == nullptr || !ch->isConnected()) {
         return false;
     }
-    socketChannel->sendSender(Protocol(actionId, address, value, peripheralIndex));
+    ch->sendSender(Protocol(actionId, address, value, peripheralIndex));
     return true;
 }
 
 bool renodeDPILog(int logLevel, const char* data)
 {
-    if(!renodeDPIIsConnected())
-    {
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    if (ch == nullptr || !ch->isConnected()) {
         return false;
     }
-    socketChannel->log(logLevel, data);
+    ch->log(logLevel, data);
     return true;
 }

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
@@ -23,6 +23,9 @@ static std::atomic<SocketCommunicationChannel*> socketChannel{nullptr};
 static std::atomic<bool> connectThreadRunning{false};
 static std::atomic<bool> shouldStopConnect{false};
 
+// Initialised true at C++ static-init time, which runs once per DLL load
+static std::atomic<bool> dllFreshSinceLoad{true};
+
 #ifdef _WIN32
 static HANDLE connectThreadHandle = NULL;
 #else
@@ -95,11 +98,12 @@ static void joinConnectThread()
 
 void renodeDPIConnect(int receiverPort, int senderPort, const char* address)
 {
-    if (renodeDPIIsConnected()) return;
+    if (renodeDPIIsConnected()) {
+        return;
+    }
 
     bool expected = false;
     if (!connectThreadRunning.compare_exchange_strong(expected, true)) {
-        // A previous connect thread is still in flight; don't spawn another.
         return;
     }
 
@@ -133,9 +137,10 @@ void renodeDPIDisconnect()
 {
     shouldStopConnect.store(true);
     joinConnectThread();
-    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    SocketCommunicationChannel* ch = socketChannel.exchange(nullptr, std::memory_order_acq_rel);
     if (ch != nullptr) {
         ch->disconnect();
+        delete ch;
     }
 }
 
@@ -194,4 +199,9 @@ bool renodeDPILog(int logLevel, const char* data)
     }
     ch->log(logLevel, data);
     return true;
+}
+
+bool renodeDPIIsDllFresh()
+{
+    return dllFreshSinceLoad.exchange(false, std::memory_order_acq_rel);
 }

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.cpp
@@ -8,15 +8,169 @@
 #include "renode_dpi.h"
 #include "communication/socket_channel.h"
 
-static SocketCommunicationChannel *socketChannel;
+#include <atomic>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <process.h>
+#else
+#include <pthread.h>
+#include <unistd.h>
+#endif
+
+const unsigned int connectionRetryDelayMs = 200;
+static std::atomic<SocketCommunicationChannel*> socketChannel{nullptr};
+static std::atomic<ConnectionStatus> connectionStatus{Unconnected};
+
+#ifdef _WIN32
+static HANDLE connectThreadHandle = NULL;
+#else
+static pthread_t connectThreadHandle;
+static bool connectThreadJoinable = false;
+#endif
+
+static void platformSleepMs(unsigned int ms)
+{
+#ifdef _WIN32
+    Sleep(ms);
+#else
+    usleep(ms * 1000);
+#endif
+}
+
+static bool tryConnect(SocketConnectionArgs* args)
+{
+    SocketCommunicationChannel* candidate = new SocketCommunicationChannel();
+    candidate->connect(args);
+
+    if (candidate->isConnected()) {
+        socketChannel.store(candidate);
+        connectionStatus.store(Connected);
+        return true;
+    }
+
+    delete candidate;
+    return false;
+}
+
+static void connectLoopBody(SocketConnectionArgs* args)
+{
+    while (connectionStatus.load() == Connecting) {
+        if(tryConnect(args)) {
+            break;
+        }
+        platformSleepMs(connectionRetryDelayMs);
+    }
+    delete args;
+}
+
+#ifdef _WIN32
+static unsigned __stdcall connectThreadEntry(void* arg)
+{
+    connectLoopBody(static_cast<SocketConnectionArgs*>(arg));
+    return 0;
+}
+#else
+static void* connectThreadEntry(void* arg)
+{
+    connectLoopBody(static_cast<SocketConnectionArgs*>(arg));
+    return nullptr;
+}
+#endif
+
+static void joinConnectThread()
+{
+#ifdef _WIN32
+    if (connectThreadHandle != NULL) {
+        WaitForSingleObject(connectThreadHandle, INFINITE);
+        CloseHandle(connectThreadHandle);
+        connectThreadHandle = NULL;
+    }
+#else
+    if (connectThreadJoinable) {
+        pthread_join(connectThreadHandle, nullptr);
+        connectThreadJoinable = false;
+    }
+#endif
+}
+
+static void renodeConnect(uint32_t receiverPort, uint32_t senderPort, const char* address, bool inBackground, uint32_t timeoutMs)
+{
+    // The only other thread that can modify the status is the connecting thread and it only sets Connected
+    ConnectionStatus status = connectionStatus.load();
+
+    if (status == Connecting || status == Connected) {
+        return;
+    }
+
+    joinConnectThread();
+
+    connectionStatus.store(Connecting);
+
+    SocketConnectionArgs* args = new SocketConnectionArgs;
+    args->receiverPort = receiverPort;
+    args->senderPort = senderPort;
+    args->address = address;
+    args->handshakeTimeout = timeoutMs;
+
+    if (!inBackground) {
+        tryConnect(args);
+
+        delete args;
+    } else {
+#ifdef _WIN32
+        connectThreadHandle = (HANDLE)_beginthreadex(
+            NULL, 0, connectThreadEntry, args, 0, NULL);
+        if (connectThreadHandle == NULL) {
+            connectionStatus.store(Error);
+            delete args;
+        }
+#else
+        if (pthread_create(&connectThreadHandle, nullptr, connectThreadEntry, args) == 0) {
+            connectThreadJoinable = true;
+        } else {
+            connectionStatus.store(Error);
+            delete args;
+        }
+#endif
+    }
+}
+
+void renodeDPIConnect(uint32_t receiverPort, uint32_t senderPort, const char* address, uint32_t timeoutMs)
+{
+    renodeConnect(receiverPort, senderPort, address, false, timeoutMs);
+}
+
+void renodeDPIConnectInBackground(uint32_t receiverPort, uint32_t senderPort, const char* address, uint32_t timeoutMs)
+{
+    renodeConnect(receiverPort, senderPort, address, true, 0);
+}
+
+void renodeDPIDisconnect()
+{
+    connectionStatus.store(Disconnected);
+    joinConnectThread();
+    SocketCommunicationChannel* ch = socketChannel.exchange(nullptr, std::memory_order_acq_rel);
+    if (ch != nullptr) {
+        ch->disconnect();
+        delete ch;
+    }
+}
 
 bool renodeDPIReceive(uint32_t* actionId, uint64_t* address, uint64_t* value, int32_t* peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
+    if (connectionStatus.load() != Connected) {
         return false;
     }
-    Protocol *message = socketChannel->receive();
+
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+
+    Protocol *message = ch->receive();
+    if (message == nullptr) {
+        return false;
+    }
+
     *actionId = message->actionId;
     *address = message->addr;
     *value = message->value;
@@ -26,51 +180,61 @@ bool renodeDPIReceive(uint32_t* actionId, uint64_t* address, uint64_t* value, in
     return true;
 }
 
-void renodeDPIConnect(int receiverPort, int senderPort, const char* address)
+bool renodeDPITryReceive(uint32_t* actionId, uint64_t* address, uint64_t* value, int32_t* peripheralIndex)
 {
-    socketChannel = new SocketCommunicationChannel();
-    socketChannel->connect(receiverPort, senderPort, address);
-}
-
-void renodeDPIDisconnect()
-{
-    if(socketChannel != NULL)
-    {
-        socketChannel->disconnect();
+    if (connectionStatus.load() != Connected) {
+        return false;
     }
-}
 
-bool renodeDPIIsConnected()
-{
-    return socketChannel != NULL && socketChannel->isConnected();
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    Protocol *message = ch->tryReceive();
+    if (message == nullptr) {
+        return false;
+    }
+
+    *actionId = message->actionId;
+    *address = message->addr;
+    *value = message->value;
+    *peripheralIndex = message->peripheralIndex;
+
+    delete message;
+    return true;
 }
 
 bool renodeDPISend(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
+    if (connectionStatus.load() != Connected) {
         return false;
     }
-    socketChannel->sendMain(Protocol(actionId, address, value, peripheralIndex));
+
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    ch->sendMain(Protocol(actionId, address, value, peripheralIndex));
     return true;
 }
 
 bool renodeDPISendToAsync(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex)
 {
-    if(!renodeDPIIsConnected())
-    {
+    if (connectionStatus.load() != Connected) {
         return false;
     }
-    socketChannel->sendSender(Protocol(actionId, address, value, peripheralIndex));
+
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    ch->sendSender(Protocol(actionId, address, value, peripheralIndex));
     return true;
 }
 
 bool renodeDPILog(int logLevel, const char* data)
 {
-    if(!renodeDPIIsConnected())
-    {
+    if (connectionStatus.load() != Connected) {
         return false;
     }
-    socketChannel->log(logLevel, data);
+
+    SocketCommunicationChannel* ch = socketChannel.load(std::memory_order_acquire);
+    ch->log(logLevel, data);
     return true;
+}
+
+int32_t renodeDPIGetConnectionStatus()
+{
+    return connectionStatus.load();
 }

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.h
@@ -17,6 +17,7 @@ extern "C"
   bool renodeDPISend(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
   bool renodeDPISendToAsync(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
   bool renodeDPILog(int logLevel, const char *data);
+  bool renodeDPIIsDllFresh();
 }
 
 #endif

--- a/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.h
+++ b/src/Plugins/CoSimulationPlugin/IntegrationLibrary/src/renode_dpi.h
@@ -10,13 +10,24 @@
 
 extern "C"
 {
-  void renodeDPIConnect(int receiverPort, int senderPort, const char *address);
+  void renodeDPIConnect(uint32_t receiverPort, uint32_t senderPort, const char *address, uint32_t timeoutMs);
+  void renodeDPIConnectInBackground(uint32_t receiverPort, uint32_t senderPort, const char *address, uint32_t timeoutMs);
   void renodeDPIDisconnect();
-  bool renodeDPIIsConnected();
+  int32_t renodeDPIGetConnectionStatus();
+  bool renodeDPITryReceive(uint32_t *actionId, uint64_t *address, uint64_t *value, int32_t *peripheralIndex);
   bool renodeDPIReceive(uint32_t *actionId, uint64_t *address, uint64_t *value, int32_t *peripheralIndex);
   bool renodeDPISend(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
   bool renodeDPISendToAsync(uint32_t actionId, uint64_t address, uint64_t value, int32_t peripheralIndex);
-  bool renodeDPILog(int logLevel, const char *data);
+  bool renodeDPILog(int32_t logLevel, const char *data);
+
+  typedef enum : int32_t {
+    Unconnected = 0,
+    NeedsReconnection = 1,
+    Connecting = 2,
+    Connected = 3,
+    Disconnected = 4,  // Indicate graceful disconnection
+    Error = 5  // Error while connecting
+  } ConnectionStatus;
 }
 
 #endif


### PR DESCRIPTION
### Description

The purpose of this PR is to update the DPI library with the following features:

- Questasim Simulation runs independently of renode, ie if renode is in debug mode the simulation keeps running
- Questasim-Renode calls are non blocking
- Integration Library now polls for renode connection rather than failling at the start if renode is not available
- support questasim snapshot feature, integration lib can detect dll load and issue a new connection request

### Usage example

run the example axi_ram using this PR's integration library
https://github.com/marcoantonio-ferrera/renode-dpi-examples/tree/main/samples/axi_ram

to test/use the snapshot feature, launch the quetasim simulation (vsim) -

1. mem WriteDoubleWord 0xDEADBEEF
2. Stop the simulation with out closing vsim
3. in the tcl console
4. enter "checkpoint snapshot.cpt"
5. close the vsim window and renode
6. relaunch  renode
7. swap the vsim command with " vsim -restore snapshot.cpt -do "run -all" "
8. read mem ReadDoubleWord 0x10 you will see "0xDEADBEEF"
