### PR TITLE
[#929] nucleo_h753zi: Set LAN8742 PHYSCSR so the netif links up

### DIFF
--- a/platforms/boards/nucleo_h753zi.repl
+++ b/platforms/boards/nucleo_h753zi.repl
@@ -25,3 +25,6 @@ phy: Network.EthernetPhysicalLayer @ ethernet 0
     AutoNegotiationLinkPartnerBasePageAbility: 0x0001
     AutoNegotiationExpansion: 0x0064
     AutoNegotiationNextPageTransmit: 0x2001
+    // PHYSCSR (LAN8742 vendor reg 0x1F). ST's LAN8742 BSP reads this for link/speed/duplex:
+    // AUTONEGDONE(b12) | HCDSPEED=100BASE-TX full-duplex(b4:2=0b110) => link up @ 100M/FD.
+    VendorSpecific15: 0x1018


### PR DESCRIPTION
Fixes #929.

ST's LAN8742 BSP (`Drivers/BSP/Components/lan8742/lan8742.c`, shipped in every CubeMX H7 Ethernet project) reads PHY register **0x1F (PHYSCSR)** in `LAN8742_GetLinkState()` to resolve link/speed/duplex. `Network.EthernetPhysicalLayer` already exposes that register as `VendorSpecific15`, but `nucleo_h753zi.repl` never set it, so stock firmware decoded "auto-neg not done" → link-down forever and lwIP's `netif` never came up — even though `BasicStatus` reported link-up.

This sets `VendorSpecific15: 0x1018` (`AUTONEGDONE` b12 | `HCDSPEED` = 100BASE-TX full-duplex, per the LAN8742A datasheet reg 31), so the stock driver resolves link-up @ 100M/FD with no firmware changes.

### Verified
On an STM32H723 platform with the same PHY block + this line, the unmodified `ethernet_link_check_state()` path brings the netif up in Renode 1.16:
```
=== STM32H723 BOOT ===
[7] Entering main loop
[net] link UP
```

Orthogonal to #626 (MAC-level EMAC completeness); this is purely the PHY link-state register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
