### PR TITLE
[#930] stm32h7: Map PWR_CSR1.ACTVOSRDY so HAL_PWREx_ConfigSupply doesn't hang

### DIFF
--- a/platforms/cpus/stm32h7.repl
+++ b/platforms/cpus/stm32h7.repl
@@ -546,6 +546,7 @@ sysbus:
         Tag <0x58027000, 0x580273FF> "RAMECC3"
         Tag <0x58025800, 0x58025BFF> "DMAMUX2"
         Tag <0x58024800, 0x58024BFF> "PWR"
+        Tag <0x58024804, 0x58024804> "CSR1" 0x2000  // PWR_CSR1.ACTVOSRDY (b13) — HAL_PWREx_ConfigSupply spins on it at boot.
         Tag <0x58024818, 0x58024818> "D3CR" 0x2000  // VOSRDY flag (b13) indicates the voltage was properly set.
         Tag <0x58005400, 0x580057FF> "SAI4"
         Tag <0x58003C00, 0x58003FFF> "VREF"


### PR DESCRIPTION
Fixes #930.

CubeMX H7 `SystemClock_Config()` calls `HAL_PWREx_ConfigSupply()`, which busy-waits on **PWR_CSR1.ACTVOSRDY** (`0x58024804`, b13) *before* the `D3CR.VOSRDY` wait that the platform already handles. `CSR1` was only covered by the broad `"PWR"` tag (returns 0), so `ACTVOSRDY` never asserted and the CPU looped forever at boot, before `main()`.

This tags `CSR1` to return `ACTVOSRDY`, mirroring the existing `D3CR.VOSRDY` tag one line below. One-line change; lets stock CubeMX H7 firmware get past clock init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
