### PR TITLE
[#789] GenericSpiNandFlash: Add generic SPI-NAND flash model and tests

### DIFF
--- a/tests/unit-tests/spi-nand-flash.robot
+++ b/tests/unit-tests/spi-nand-flash.robot
@@ -1,0 +1,33 @@
+*** Keywords ***
+Create Machine
+    Execute Command           mach create
+    Execute Command           using sysbus
+    Execute Command           machine LoadPlatformDescriptionFromString "spi: SPI.HiFive_SPI @ sysbus 0x10000000; spiNand: SPI.GenericSpiNandFlash @ spi 0 { manufacturerId: 0x52; deviceId: 0x24; blocksCount: 1024; pageSize: 2048; spareSize: 64 }"
+
+Create Winbond Machine
+    Execute Command           mach create
+    Execute Command           using sysbus
+    Execute Command           machine LoadPlatformDescriptionFromString "spi: SPI.HiFive_SPI @ sysbus 0x10000000; spiNand: SPI.GenericSpiNandFlash @ spi 0 { manufacturerId: 0xEF; deviceId: 0xAA21; blocksCount: 2048; pageSize: 2048; spareSize: 64 }"
+
+*** Test Cases ***
+Should Instantiate GenericSpiNandFlash From Repl
+    Create Machine
+    ${manId}=                 Execute Command  spi.spiNand ManufacturerId
+    Should Be Equal As Strings  ${manId}  0x52  strip_spaces=True
+    ${devId}=                 Execute Command  spi.spiNand DeviceId
+    Should Be Equal As Strings  ${devId}  0x0024  strip_spaces=True
+    ${pageSize}=              Execute Command  spi.spiNand PageSize
+    Should Be Equal As Strings  ${pageSize}  0x00000800  strip_spaces=True
+    ${spareSize}=             Execute Command  spi.spiNand SpareSize
+    Should Be Equal As Strings  ${spareSize}  0x00000040  strip_spaces=True
+    ${blocksCount}=           Execute Command  spi.spiNand BlocksCount
+    Should Be Equal As Strings  ${blocksCount}  0x00000400  strip_spaces=True
+
+Should Instantiate Winbond Flash With 16Bit DeviceId
+    Create Winbond Machine
+    ${manId}=                 Execute Command  spi.spiNand ManufacturerId
+    Should Be Equal As Strings  ${manId}  0xEF  strip_spaces=True
+    ${devId}=                 Execute Command  spi.spiNand DeviceId
+    Should Be Equal As Strings  ${devId}  0xAA21  strip_spaces=True
+    ${blocksCount}=           Execute Command  spi.spiNand BlocksCount
+    Should Be Equal As Strings  ${blocksCount}  0x00000800  strip_spaces=True


### PR DESCRIPTION
### Related issue

Resolves #789
Depends on renode/renode-infrastructure#229

### Description

**New Feature / Improvement**:
Updates the `src/Infrastructure` submodule to include the `GenericSpiNandFlash` peripheral model and adds a Robot Framework test suite verifying `.repl` platform description parsing, parameter configuration, and Monitor property access.

### Usage example

Example platform description (`.repl`):

```text
spi: SPI.HiFive_SPI @ sysbus 0x10000000

spiNand: SPI.GenericSpiNandFlash @ spi 0
    manufacturerId: 0x52
    deviceId: 0x24
    blocksCount: 1024
    pageSize: 2048
    spareSize: 64
```

In Renode Monitor:
```text
(monitor) spi.spiNand ManufacturerId
0x52
(monitor) spi.spiNand DeviceId
0x0024
```

### Additional information

Automated test suite `tests/unit-tests/spi-nand-flash.robot` runs and passes with `renode-test`.
