### PR TITLE
[#970] MCXN947: Add initial platform support

### DIFF
--- a/platforms/boards/frdm_mcxn947.repl
+++ b/platforms/boards/frdm_mcxn947.repl
@@ -1,0 +1,31 @@
+using "platforms/cpus/mcxn947.repl"
+
+gpio0:
+    10 -> led0@0
+    27 -> led1@0
+
+gpio1:
+    2 -> led2@0
+
+led0: Miscellaneous.LED @ gpio0 10
+    invert: true
+
+led1: Miscellaneous.LED @ gpio0 27
+    invert: true
+
+led2: Miscellaneous.LED @ gpio1 2
+    invert: true
+
+sw2: Miscellaneous.Button @ gpio0 23
+    invert: true
+    -> gpio0@23
+
+sw3: Miscellaneous.Button @ gpio0 6
+    invert: true
+    -> gpio0@6
+
+resetPin: Miscellaneous.ResetPin @ gpio0 31
+
+resetButton: Miscellaneous.Button @ gpio0 31
+    invert: true
+    -> resetPin@0

--- a/platforms/cpus/mcxn947.repl
+++ b/platforms/cpus/mcxn947.repl
@@ -1,0 +1,191 @@
+cpu0: CPU.CortexM @ sysbus
+    cpuType: "cortex-m33"
+    cpuId: 0
+    nvic: nvic0
+
+cpu1: CPU.CortexM @ sysbus
+    cpuType: "cortex-m33"
+    cpuId: 1
+    nvic: nvic1
+    init:
+        IsHalted true
+
+nvic0: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
+        address: 0xE000E000;
+        cpu: cpu0
+    }
+    systickFrequency: 150000000
+    -> cpu0@0
+
+nvic1: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
+        address: 0xE000E000;
+        cpu: cpu1
+    }
+    systickFrequency: 150000000
+    -> cpu1@0
+
+flash: Memory.MappedMemory @ {
+        sysbus 0x00000000;
+        sysbus 0x10000000
+    }
+    size: 0x200000
+
+sramx: Memory.MappedMemory @ {
+        sysbus 0x04000000;
+        sysbus 0x14000000
+    }
+    size: 0x18000
+
+sram: Memory.MappedMemory @ {
+        sysbus 0x20000000;
+        sysbus 0x30000000
+    }
+    size: 0x60000
+
+sramh: Memory.MappedMemory @ {
+        sysbus 0x20060000;
+        sysbus 0x30060000
+    }
+    size: 0x8000
+
+flexcomm0: UART.NXP_FLEXCOMM @ {
+        sysbus 0x40092000;
+        sysbus 0x50092000
+    }
+    IRQ -> nvic0@35
+
+flexcomm1: UART.NXP_FLEXCOMM @ {
+        sysbus 0x40093000;
+        sysbus 0x50093000
+    }
+    IRQ -> nvic0@36
+
+flexcomm2: UART.NXP_FLEXCOMM @ {
+        sysbus 0x40094000;
+        sysbus 0x50094000
+    }
+    IRQ -> nvic0@37
+
+flexcomm3: UART.NXP_FLEXCOMM @ {
+        sysbus 0x40095000;
+        sysbus 0x50095000
+    }
+    IRQ -> nvic0@38
+
+flexcomm4: UART.NXP_FLEXCOMM @ {
+        sysbus 0x400B4000;
+        sysbus 0x500B4000
+    }
+    IRQ -> nvic0@39
+
+flexcomm5: UART.NXP_FLEXCOMM @ {
+        sysbus 0x400B5000;
+        sysbus 0x500B5000
+    }
+    IRQ -> nvic0@40
+
+flexcomm6: UART.NXP_FLEXCOMM @ {
+        sysbus 0x400B6000;
+        sysbus 0x500B6000
+    }
+    IRQ -> nvic0@41
+
+flexcomm7: UART.NXP_FLEXCOMM @ {
+        sysbus 0x400B7000;
+        sysbus 0x500B7000
+    }
+    IRQ -> nvic0@42
+
+flexcomm8: UART.NXP_FLEXCOMM @ {
+        sysbus 0x400B8000;
+        sysbus 0x500B8000
+    }
+    IRQ -> nvic0@43
+
+flexcomm9: UART.NXP_FLEXCOMM @ {
+        sysbus 0x400B9000;
+        sysbus 0x500B9000
+    }
+    IRQ -> nvic0@44
+
+gpio0: GPIOPort.MCXN94_GPIO @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40096000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40116000; size: 0x1000; region: "port" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50096000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50116000; size: 0x1000; region: "port" }
+    }
+    IRQ0 -> nvic0@17
+    IRQ1 -> nvic0@18
+
+gpio1: GPIOPort.MCXN94_GPIO @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40098000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40117000; size: 0x1000; region: "port" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50098000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50117000; size: 0x1000; region: "port" }
+    }
+    IRQ0 -> nvic0@19
+    IRQ1 -> nvic0@20
+
+gpio2: GPIOPort.MCXN94_GPIO @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x4009A000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40118000; size: 0x1000; region: "port" };
+        sysbus new Bus.BusMultiRegistration { address: 0x5009A000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50118000; size: 0x1000; region: "port" }
+    }
+    IRQ0 -> nvic0@21
+    IRQ1 -> nvic0@22
+
+gpio3: GPIOPort.MCXN94_GPIO @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x4009C000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40119000; size: 0x1000; region: "port" };
+        sysbus new Bus.BusMultiRegistration { address: 0x5009C000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50119000; size: 0x1000; region: "port" }
+    }
+    IRQ0 -> nvic0@23
+    IRQ1 -> nvic0@24
+
+gpio4: GPIOPort.MCXN94_GPIO @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x4009E000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x4011A000; size: 0x1000; region: "port" };
+        sysbus new Bus.BusMultiRegistration { address: 0x5009E000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x5011A000; size: 0x1000; region: "port" }
+    }
+    IRQ0 -> nvic0@25
+    IRQ1 -> nvic0@26
+
+gpio5: GPIOPort.MCXN94_GPIO @ {
+        sysbus new Bus.BusMultiRegistration { address: 0x40040000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x40042000; size: 0x1000; region: "port" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50040000; size: 0x1000; region: "gpio" };
+        sysbus new Bus.BusMultiRegistration { address: 0x50042000; size: 0x1000; region: "port" }
+    }
+    IRQ0 -> nvic0@27
+    IRQ1 -> nvic0@28
+
+wwdt0: Timers.MCXN94_WWDT @ {
+        sysbus 0x40016000;
+        sysbus 0x50016000
+    }
+    frequency: 1000000
+    -> nvic0@152
+
+wwdt1: Timers.MCXN94_WWDT @ {
+        sysbus 0x40017000;
+        sysbus 0x50017000
+    }
+    frequency: 1000000
+    -> nvic0@153
+
+cdog0: Timers.MCXN94_CDOG @ {
+        sysbus 0x400BB000;
+        sysbus 0x500BB000
+    }
+    frequency: 1000000
+    -> nvic0@93
+
+cdog1: Timers.MCXN94_CDOG @ {
+        sysbus 0x400BC000;
+        sysbus 0x500BC000
+    }
+    frequency: 1000000
+    -> nvic0@94

--- a/tests/platforms/MCXN947.robot
+++ b/tests/platforms/MCXN947.robot
@@ -1,0 +1,240 @@
+*** Settings ***
+Test Setup                      Create Machine
+
+*** Variables ***
+${PLATFORM}                     platforms/boards/frdm_mcxn947.repl
+
+${GPIO_PSOR}                    0x44
+${GPIO_PCOR}                    0x48
+${GPIO_PDIR}                    0x50
+${GPIO_PDDR}                    0x54
+${GPIO_ICR_BASE}                0x80
+${GPIO_ISF0}                    0x120
+${GPIO_ISF1}                    0x124
+
+${FLEXCOMM_PSELID}              0xFF8
+${FLEXCOMM_STAT}                0xFF4
+${LPSPI_CR}                     0x10
+${LPSPI_IER}                    0x18
+${LPSPI_SR}                     0x14
+${LPSPI_CFGR1}                  0x24
+${LPSPI_TCR}                    0x60
+${LPSPI_TDR}                    0x64
+${LPI2C_MCR}                    0x810
+${LPI2C_MIER}                   0x818
+${LPI2C_MTDR}                   0x860
+${LPI2C_MRDR}                   0x870
+
+${WWDT_MOD}                     0x0
+${WWDT_TC}                      0x4
+${WWDT_FEED}                    0x8
+${WWDT_WARNINT}                 0x14
+
+*** Keywords ***
+Create Machine
+    Execute Command             mach create
+    Execute Command             machine LoadPlatformDescription @${PLATFORM}
+    Execute Command             macro reset "cpu0 IsHalted true; cpu1 IsHalted true"
+    Create Log Tester           timeout=1  defaultPauseEmulation=True
+
+Connect LED To GPIO Pin
+    [Arguments]                 ${pin}
+    Execute Command             machine LoadPlatformDescriptionFromString "gpio0: { ${pin} -> testLed${pin}@0 }; testLed${pin}: Miscellaneous.LED @ gpio0 ${pin}"
+
+Connect Button To GPIO Pin
+    [Arguments]                 ${pin}
+    Execute Command             machine LoadPlatformDescriptionFromString "button${pin}: Miscellaneous.Button @ gpio0 ${pin} { -> gpio0@${pin} }"
+
+Halt CPUs
+    Run Keyword And Ignore Error    Execute Command  cpu0 IsHalted true
+    Run Keyword And Ignore Error    Execute Command  cpu1 IsHalted true
+
+GPIO Interrupt Control Offset
+    [Arguments]                 ${pin}
+    ${offset}=                  Evaluate  ${GPIO_ICR_BASE} + (4 * ${pin})
+    [Return]                    ${offset}
+
+GPIO Should Have Bit Set
+    [Arguments]                 ${value}  ${bit}
+    ${mask}=                    Evaluate  1 << ${bit}
+    ${masked}=                  Evaluate  int(${value}) & ${mask}
+    Should Not Be Equal As Integers  ${masked}  0
+
+GPIO Should Have Bit Cleared
+    [Arguments]                 ${value}  ${bit}
+    ${mask}=                    Evaluate  1 << ${bit}
+    ${masked}=                  Evaluate  int(${value}) & ${mask}
+    Should Be Equal As Integers     ${masked}  0
+
+Signal Should Be
+    [Arguments]                 ${signal_path}  ${expected}
+    ${state}=                   Execute Command  ${signal_path} IsSet
+    Should Be Equal             ${state.strip()}  ${expected}
+
+Configure Rising Edge IRQ
+    [Arguments]                 ${pin}  ${route_to_irq1}=False
+    ${offset}=                  GPIO Interrupt Control Offset  ${pin}
+    ${value}=                   Set Variable  0x00090000
+    IF  ${route_to_irq1}
+        ${value}=               Set Variable  0x00190000
+    END
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${offset} ${value}
+
+Set Flexcomm Mode
+    [Arguments]                 ${instance}  ${mode}
+    Execute Command             ${instance} WriteDoubleWord ${FLEXCOMM_PSELID} ${mode}
+
+Configure WWDT Warning Window
+    [Arguments]                 ${instance}
+    Execute Command             ${instance} WriteDoubleWord ${WWDT_TC} 0x20
+    Execute Command             ${instance} WriteDoubleWord ${WWDT_WARNINT} 0x10
+
+Feed WWDT
+    [Arguments]                 ${instance}
+    Execute Command             ${instance} WriteDoubleWord ${WWDT_FEED} 0xAA
+    Execute Command             ${instance} WriteDoubleWord ${WWDT_FEED} 0x55
+
+Enable WWDT
+    [Arguments]                 ${instance}  ${with_reset}=False
+    ${mod}=                     Set Variable  0x1
+    IF  ${with_reset}
+        ${mod}=                 Set Variable  0x3
+    END
+    Execute Command             ${instance} WriteDoubleWord ${WWDT_MOD} ${mod}
+
+*** Test Cases ***
+Should Restore GPIO Defaults When Reset Pin Is Asserted
+    Halt CPUs
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_PDDR} 0x1
+    ${before_reset}=            Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_PDDR}
+    Should Be Equal As Integers  ${before_reset.strip()}  0x1
+
+    Execute Command             sysbus.gpio0.resetPin OnGPIO 0 false
+    Execute Command             emulation RunFor "0.001"
+
+    ${after_reset}=             Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_PDDR}
+    Should Be Equal As Integers  ${after_reset.strip()}  0x0
+
+Should Drive GPIO Outputs And Sample GPIO Inputs
+    Execute Command             emulation Mode SynchronizedTimers
+    Connect LED To GPIO Pin     0
+    Connect Button To GPIO Pin  1
+    ${led}=                     Create LED Tester  sysbus.gpio0.testLed0  defaultTimeout=0
+
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_PDDR} 0x1
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_PSOR} 0x1
+    Assert LED State            true  testerId=${led}
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_PCOR} 0x1
+    Assert LED State            false  testerId=${led}
+
+    Execute Command             sysbus.gpio0.button1 Press
+    ${pdir_high}=               Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_PDIR}
+    GPIO Should Have Bit Set    ${pdir_high.strip()}  1
+    Execute Command             sysbus.gpio0.button1 Release
+    ${pdir_low}=                Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_PDIR}
+    GPIO Should Have Bit Cleared  ${pdir_low.strip()}  1
+
+Should Route GPIO Interrupts To Both IRQ Outputs And Clear Their Flags
+    Configure Rising Edge IRQ   2
+    Configure Rising Edge IRQ   3  route_to_irq1=${True}
+
+    Execute Command             gpio0 OnGPIO 2 true
+    Signal Should Be            gpio0 IRQ0  True
+    Signal Should Be            gpio0 IRQ1  False
+    ${irq0_flags}=              Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_ISF0}
+    GPIO Should Have Bit Set    ${irq0_flags.strip()}  2
+
+    Execute Command             gpio0 OnGPIO 3 true
+    Signal Should Be            gpio0 IRQ1  True
+    ${irq1_flags}=              Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_ISF1}
+    GPIO Should Have Bit Set    ${irq1_flags.strip()}  3
+
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_ISF0} 0x4
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_ISF1} 0x8
+    Signal Should Be            gpio0 IRQ0  False
+    Signal Should Be            gpio0 IRQ1  False
+
+Should Transfer A Byte Over LPSPI To Dummy Slave
+    Execute Command             machine LoadPlatformDescriptionFromString "dummySlave: Mocks.DummySPISlave @ flexcomm0 0"
+    Execute Command             logLevel 0 sysbus.flexcomm0.flexcomm0_spi.dummySlave
+
+    Set Flexcomm Mode           flexcomm0  0x2
+    Execute Command             flexcomm0 WriteDoubleWord ${LPSPI_CFGR1} 0x1
+    Execute Command             flexcomm0 WriteDoubleWord ${LPSPI_CR} 0x1
+    Execute Command             flexcomm0 WriteDoubleWord ${LPSPI_IER} 0x400
+    Execute Command             flexcomm0 WriteDoubleWord ${LPSPI_TCR} 0x7
+    Execute Command             flexcomm0 WriteDoubleWord ${LPSPI_TDR} 0xA5
+
+    Wait For Log Entry          Data received: 0xA5
+    Signal Should Be            flexcomm0 IRQ  True
+    ${status}=                  Execute Command  flexcomm0 ReadDoubleWord ${FLEXCOMM_STAT}
+    GPIO Should Have Bit Set    ${status.strip()}  2
+    Execute Command             flexcomm0 WriteDoubleWord ${LPSPI_SR} 0x400
+    Signal Should Be            flexcomm0 IRQ  False
+
+Should Transfer Data Over I2C To Echo Device
+    Execute Command             machine LoadPlatformDescriptionFromString "i2cEcho: Mocks.EchoI2CDevice @ flexcomm1 0x55"
+
+    Set Flexcomm Mode           flexcomm1  0x3
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MCR} 0x1
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MIER} 0x1
+    Signal Should Be            flexcomm1 IRQ  True
+    ${status}=                  Execute Command  flexcomm1 ReadDoubleWord ${FLEXCOMM_STAT}
+    GPIO Should Have Bit Set    ${status.strip()}  4
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MIER} 0x0
+    Signal Should Be            flexcomm1 IRQ  False
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MTDR} 0x4AA
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MTDR} 0x23
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MTDR} 0x200
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MTDR} 0x4AB
+    Execute Command             flexcomm1 WriteDoubleWord ${LPI2C_MTDR} 0x100
+
+    ${readback}=                Execute Command  flexcomm1 ReadDoubleWord ${LPI2C_MRDR}
+    ${data}=                    Evaluate  int(${readback}) & 0xFF
+    Should Be Equal As Integers  ${data}  0x23
+
+Should Raise WWDT Warning IRQ And Clear It After A Valid Feed
+    Halt CPUs
+    Configure WWDT Warning Window  wwdt0
+    Enable WWDT                 wwdt0
+
+    Execute Command             emulation RunFor "1"
+    Signal Should Be            wwdt0 IRQ  True
+
+    Feed WWDT                   wwdt0
+    Execute Command             wwdt0 WriteDoubleWord ${WWDT_MOD} 0x8
+    Signal Should Be            wwdt0 IRQ  False
+
+Should Reset The Machine When WWDT Expires With Reset Enabled
+    Halt CPUs
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_PDDR} 0x1
+    Configure WWDT Warning Window  wwdt1
+    Enable WWDT                 wwdt1  with_reset=${True}
+
+    Execute Command             emulation RunFor "2"
+
+    ${pddr_after_reset}=        Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_PDDR}
+    Should Be Equal As Integers  ${pddr_after_reset.strip()}  0x0
+
+Should Raise CDOG Fault Injection IRQs And Reset On Configured Timeout Fault
+    Halt CPUs
+    # CONTROL: unlocked, timeout->reset, miscompare->IRQ, sequence->IRQ.
+    Execute Command             cdog0 WriteDoubleWord 0x0 0x246
+    Execute Command             cdog0 InjectMiscompareFault
+    Signal Should Be            cdog0 IRQ  True
+    Execute Command             cdog0 WriteDoubleWord 0x18 0x2
+    Signal Should Be            cdog0 IRQ  False
+
+    Execute Command             cdog0 InjectIllegalSequenceFault
+    Signal Should Be            cdog0 IRQ  True
+    Execute Command             cdog0 WriteDoubleWord 0x18 0x4
+    Signal Should Be            cdog0 IRQ  False
+
+    Execute Command             gpio0 WriteDoubleWordToGPIO ${GPIO_PDDR} 0x1
+    Execute Command             cdog0 InjectTimeoutFault
+    Execute Command             emulation RunFor "0.001"
+    ${after_fault_reset}=       Execute Command  gpio0 ReadDoubleWordFromGPIO ${GPIO_PDDR}
+    Should Be Equal As Integers  ${after_fault_reset.strip()}  0x0
+    ${flags_after_reset}=       Execute Command  cdog0 ReadDoubleWord 0x18
+    GPIO Should Have Bit Set    ${flags_after_reset.strip()}  0
+    Signal Should Be            cdog0 IRQ  False

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -74,6 +74,7 @@
 - tests/platforms/LiteX/LiteX_VexRiscv_Linux_SDCard.robot
 - tests/platforms/LiteX/LiteX_VexRiscv_I2S.robot
 - tests/platforms/NXP-K64F.robot
+- tests/platforms/MCXN947.robot
 - tests/platforms/STM32F4_Discovery.robot
 - tests/unit-tests/riscv-custom-instructions.robot
 - tests/unit-tests/riscv-lr-sc-instructions.robot


### PR DESCRIPTION
### Related issue

#970

### Description

This draft adds initial NXP MCXN947 and FRDM-MCXN947 support:

* dual Cortex-M33 cores and the documented flash/SRAM aliases;
* ten LPFlexcomm instances and their IRQ routing;
* six GPIO/PORT instances with dual interrupt outputs;
* two WWDT and two CDOG instances;
* FRDM-MCXN947 LEDs, user buttons, and reset input;
* a firmware-free Robot suite covering reset, GPIO I/O, GPIO IRQ routing, SPI and I2C data/IRQ paths, WWDT warning/reset behavior, and CDOG fault injection/reset behavior.

The peripheral implementation is proposed in renode/renode-infrastructure#231. This branch currently references that PR's head commit, which is fetchable from the upstream submodule remote through GitHub's pull-request ref. Before final review, the submodule pointer will be replaced with the merged infrastructure SHA.

### Usage example

Load the board description:

```resc
mach create
machine LoadPlatformDescription @platforms/boards/frdm_mcxn947.repl
```

Run the self-contained regression suite:

```shell
python tests/run_tests.py --skip-building tests/platforms/MCXN947.robot
```

The in-tree Robot suite is the reproduction for the initial support. It requires no firmware binary or external download.

### Verification

* Managed Renode solution build: passed.
* Direct FRDM-MCXN947 platform load: passed.
* Infrastructure `dotnet format --verify-no-changes`: passed.
* Infrastructure peripheral tests: 100 passed, 5 skipped.
* MCXN947 Robot suite: 8 passed.
* Exact infrastructure commit fetch from `https://github.com/renode/renode-infrastructure.git`: passed.
* `git diff --check`: passed in both repositories.
* Every infrastructure commit and the platform commit were compiled independently.

### Additional information

This is initial peripheral-focused support. Clock/reset-tree modeling, DMA, functional pin-mux signal routing, LPI2C target mode, LPSPI slave mode, and booting production MCUXpresso or Zephyr firmware remain outside this draft.

CDOG fault flags and persistent data intentionally survive software reset, matching NXP's documented behavior.
