### PR TITLE
tools: Add Renode MCP server

### DIFF
--- a/tools/renode_mcp_server/README.md
+++ b/tools/renode_mcp_server/README.md
@@ -1,0 +1,213 @@
+## Control Renode from an MCP-compatible AI agent
+
+This directory contains a local stdio Model Context Protocol (MCP) server
+that allows an AI agent to control one Renode session. The server starts
+Renode with its monitor enabled, translates MCP tool calls into monitor
+commands, and returns the textual result to the agent.
+
+The server works with any agent host that supports **stdio MCP servers** and
+tool calls. Codex is only one possible host; it is not required. A Traditional
+Chinese guide is available in [README.zh-TW.md](README.zh-TW.md).
+
+> **Status:** experimental and local-only. The server controls Renode
+> simulation; it does not connect to, flash, or replace physical hardware.
+
+### Requirements
+
+* Python 3.9 or newer. No third-party Python packages are required.
+* A local Renode executable. Verify it with `renode --version` or
+  `/absolute/path/to/renode --version`.
+* A .NET runtime only if the selected Renode wrapper needs it. For a source
+  build, pass `DOTNET_ROOT` and add its directory to `PATH`.
+* An agent host capable of starting a local stdio MCP process, calling tools,
+  using loopback TCP, and reading/writing the firmware project directory.
+
+The server listens for MCP JSON-RPC messages on standard input/output. It
+starts Renode's monitor on a random `127.0.0.1` port; no TCP MCP endpoint is
+exposed. The agent host must not add protocol logs to the server's standard
+output.
+
+### Usage
+
+```
+usage: server.py [-h] [--renode RENODE] [--timeout TIMEOUT] [--show-ui]
+
+Expose a Renode monitor as an MCP server over stdio.
+
+optional arguments:
+  -h, --help         show this help message and exit
+  --renode RENODE    Renode executable (default: renode from PATH)
+  --timeout TIMEOUT  Monitor startup/response timeout in seconds (default: 10)
+  --show-ui          Keep Renode's native UI visible instead of running headless
+```
+
+Run the server only through an MCP host. For diagnostics, `--help` is safe to
+run directly; a normal direct invocation waits for MCP JSON-RPC input.
+
+### Configure your AI agent
+
+Register this executable as a stdio MCP server in the configuration for your
+agent host. The configuration syntax varies by host, but the process contract
+is always the same:
+
+```text
+command: /usr/bin/python3
+args:
+  - /absolute/path/to/renode/tools/renode_mcp_server/server.py
+  - --renode
+  - /absolute/path/to/renode/renode
+environment (source build only):
+  DOTNET_ROOT: /absolute/path/to/dotnet
+  PATH: /absolute/path/to/dotnet:/usr/local/bin:/usr/bin:/bin
+```
+
+With a packaged Renode installation, omit `DOTNET_ROOT` and set `PATH` only
+when it is needed to locate `renode`.
+
+For hosts using a JSON-style MCP configuration, the equivalent minimal setup
+looks like this. Add the `env` object when the Renode executable requires it.
+
+```json
+{
+  "mcpServers": {
+    "renode": {
+      "command": "/usr/bin/python3",
+      "args": [
+        "/absolute/path/to/renode/tools/renode_mcp_server/server.py",
+        "--renode",
+        "/absolute/path/to/renode/renode"
+      ]
+    }
+  }
+}
+```
+
+After changing the host configuration, start a new agent session. The agent
+should discover the `renode` tools with `tools/list`, then call them using the
+standard MCP `tools/call` method.
+
+#### Codex CLI example
+
+Codex users can register the same process with:
+
+```sh
+codex mcp add renode \
+  --env DOTNET_ROOT="/absolute/path/to/dotnet" \
+  --env PATH="/absolute/path/to/dotnet:/usr/local/bin:/usr/bin:/bin" \
+  -- /usr/bin/python3 \
+  "/absolute/path/to/renode/tools/renode_mcp_server/server.py" \
+  --renode "/absolute/path/to/renode/renode"
+```
+
+Confirm it with `codex mcp get renode --json`. The
+`codex.renode.toml.example` file is an equivalent configuration template.
+
+### Tools
+
+| Tool | Required input | Result |
+| --- | --- | --- |
+| `renode_start` | Optional `script` path | Starts Renode and optionally loads a `.resc` script. |
+| `renode_stop` | None | Stops the Renode child process. |
+| `renode_command` | `command` | Runs one Renode monitor command. |
+| `renode_system_info` | None | Returns virtual time and emulator state. |
+| `renode_open_uart_analyzer` | Optional `peripheral` | Opens a native UART analyzer; requires `--show-ui`. |
+| `project_create` | `project_dir`, `manifest` | Creates a firmware project scaffold and Renode scenario. |
+| `project_build` | `project_dir` | Builds a generated project and finds artifacts. |
+| `project_artifacts` | `project_dir` | Lists ELF/BIN/HEX/MAP artifacts. |
+| `renode_load_elf` | `project_dir` | Loads the project's ARM ELF into the current machine. |
+| `renode_verify_project` | `project_dir` | Loads an ARM ELF, starts emulation, and returns a report. |
+| `renode_run_project` | `project_dir` | Alias for `renode_verify_project`. |
+
+### Examples
+
+#### Check that an agent can control Renode
+
+In a new session, tell your agent:
+
+```text
+Use the renode MCP. Call renode_start, renode_system_info,
+renode_command with command "version", and renode_stop in that order.
+Report the result of every tool call.
+```
+
+Success means the agent receives `Renode is running.`, time-source output
+containing `Elapsed Virtual Time` and `State`, Renode version information, and
+`Renode stopped.`.
+
+#### Run an existing board simulation
+
+Provide the agent with a board-specific `.resc` script, its referenced `.repl`
+platform description, and an ARM ELF. Then ask:
+
+```text
+Use renode_start with /path/to/board.resc. Load the ARM ELF from the project
+with renode_load_elf, start the emulation with renode_command, then call
+renode_system_info. Report the virtual time, state, and monitor output.
+```
+
+Use `renode_stop` after the inspection. The `.resc` script must create the
+machine and define the peripherals that the firmware expects.
+
+#### Create a project scaffold
+
+Ask the agent:
+
+```text
+Use project_create to create /tmp/led-breathing for an STM32F401RE with an
+active-high LED on PA5, a 2000 ms breathing period, and sysbus.usart2.
+Call project_build and project_artifacts. After an ARM ELF is available,
+call renode_verify_project and report the result.
+```
+
+The `project_create` manifest accepts this shape:
+
+```json
+{
+  "name": "led_breathing",
+  "board": {
+    "mcu": "STM32F401RE",
+    "datasheet": "/workspace/docs/STM32F401RE.pdf",
+    "renode_platform": "platforms/cpus/stm32f4.repl",
+    "elf_machine": 40
+  },
+  "requirements": {
+    "led_gpio": "PA5",
+    "led_active_high": true,
+    "breath_period_ms": 2000,
+    "uart": "sysbus.usart2"
+  }
+}
+```
+
+#### Open a UART analyzer for a human observer
+
+Add `--show-ui` to the server arguments and ensure the host has Renode's
+native GTK/desktop dependencies. After loading a scenario that defines
+`sysbus.usart2`, ask the agent to call `renode_open_uart_analyzer` with
+`peripheral: "sysbus.usart2"`.
+
+The analyzer window is for a human observer. This server does not yet capture
+analyzer pixels or stream UART text back as a dedicated MCP tool.
+
+### Limitations
+
+* `project_create` creates a toolchain-neutral CMake skeleton. It does not
+  generate vendor HAL/CMSIS code, startup code, linker scripts, or a
+  board-accurate peripheral model from a datasheet.
+* The `datasheet` manifest field is recorded and its local-file existence is
+  reported; the server does not parse the datasheet.
+* A native `project_build` produces a host ELF. STM32 simulation needs an
+  `arm-none-eabi` toolchain and an `EM_ARM` ELF.
+* `renode_verify_project` checks ELF architecture, loads firmware, starts
+  emulation, and returns generated assertions. It does **not** execute those
+  assertions or prove GPIO/PWM behaviour.
+* A board-specific `.repl`/`.resc` is required. Renode simulation is not a
+  substitute for final hardware-in-the-loop testing or flashing a board.
+
+### Test
+
+Run from the Renode repository root:
+
+```sh
+python3 -m unittest discover -s tools/renode_mcp_server -p 'test_*.py'
+```

--- a/tools/renode_mcp_server/README.zh-TW.md
+++ b/tools/renode_mcp_server/README.zh-TW.md
@@ -1,0 +1,184 @@
+# Renode MCP Server：通用 MCP Client 使用指南
+
+這個 MCP server 透過 stdio 接收 AI agent 的工具呼叫，並在本機啟動 Renode；它只會將 Renode monitor 綁定到 `127.0.0.1`，不會暴露網路服務。
+
+> **目前狀態：** 這是實驗性的本機 MCP bridge。它控制 Renode 模擬器，不會連接、燒錄或取代實體開發板。
+
+## 使用前需要什麼？
+
+任何支援 **stdio MCP** 與 tool call 的 AI agent host 都可以使用這個 server；Codex Desktop/CLI 只是其中一個設定範例。執行 `codex mcp get renode --json` **之前不需要啟動 Renode**，但這個指令只適用於檢查 Codex 是否已註冊此 MCP server。
+
+每位使用者需要：
+
+1. 安裝支援 stdio MCP server 的 AI agent host，且它可執行本機 child process、使用 loopback TCP，並可讀寫 firmware project 目錄。
+2. 安裝 Python 3，且 `python3 --version` 可執行。
+3. 安裝或編譯 Renode，並確認 `renode --version` 可執行。
+4. 若使用此 repository 編譯的 `./renode` wrapper，還需要 .NET SDK，並在 MCP 環境中設定 `DOTNET_ROOT` 與 `PATH`。
+
+> 安裝好的 Renode 發行版本通常可直接使用；只有從原始碼執行 Renode 時才需要自行提供 .NET runtime。
+
+## 1. 取得程式碼與 Renode
+
+```sh
+git clone --recurse-submodules https://github.com/renode/renode.git
+cd renode
+```
+
+依 Renode 的官方安裝方式安裝發行版，或依專案建置文件完成原始碼建置。完成後記下下列三個**絕對路徑**：
+
+- `RENODE_ROOT`：Renode repository 根目錄。
+- `RENODE_EXECUTABLE`：Renode 執行檔；原始碼建置通常是 `$RENODE_ROOT/renode`。
+- `DOTNET_ROOT`：只有原始碼建置需要的 .NET runtime 目錄。
+
+確認：
+
+```sh
+"$RENODE_EXECUTABLE" --version
+python3 --version
+codex --version
+```
+
+## 2. 連接任何 stdio MCP Host
+
+在你的 agent host 中設定下列 command、args 與 environment，並將大寫 placeholder 換成 host 機器上的絕對路徑：
+
+```text
+command: /usr/bin/python3
+args:
+  - /ABSOLUTE/PATH/TO/renode/tools/renode_mcp_server/server.py
+  - --renode
+  - /ABSOLUTE/PATH/TO/renode/renode
+environment（僅 source build 需要）:
+  DOTNET_ROOT: /ABSOLUTE/PATH/TO/dotnet
+  PATH: /ABSOLUTE/PATH/TO/dotnet:/usr/local/bin:/usr/bin:/bin
+```
+
+各 agent host 的設定檔格式不同，但都必須以 stdio 執行上述命令。此 server 使用換行分隔的 JSON-RPC，**不需要也不應改成 HTTP 或網路 MCP endpoint**。修改設定後，請開啟新的 agent session。
+
+若使用安裝版 Renode 而非原始碼建置，移除 `DOTNET_ROOT`，並將 `PATH` 設為包含 `renode` 的目錄即可。
+
+### Codex CLI 範例
+
+建議先以 headless 模式測試，這不依賴原生 GUI。以下範例請以你的絕對路徑取代大寫 placeholder：
+
+```sh
+codex mcp add renode \
+  --env DOTNET_ROOT="/ABSOLUTE/PATH/TO/dotnet" \
+  --env PATH="/ABSOLUTE/PATH/TO/dotnet:/usr/local/bin:/usr/bin:/bin" \
+  -- /usr/bin/python3 \
+  "/ABSOLUTE/PATH/TO/renode/tools/renode_mcp_server/server.py" \
+  --renode "/ABSOLUTE/PATH/TO/renode/renode"
+```
+
+確認 Codex 註冊成功：
+
+```sh
+codex mcp get renode --json
+```
+
+預期輸出包含：
+
+```json
+{"name":"renode","enabled":true}
+```
+
+開啟新的 Codex task 後，agent 才會使用更新後的 MCP 設定。要刪除 Codex 設定可執行：
+
+```sh
+codex mcp remove renode
+```
+
+## 3. 最小 smoke test
+
+在新的 agent session 貼上：
+
+```text
+請使用 renode MCP，依序呼叫 renode_start、renode_system_info、
+renode_command（command 為 version）與 renode_stop。請列出每個工具的回傳結果。
+```
+
+成功條件：
+
+- `renode_start` 回傳 `Renode is running.`
+- `renode_system_info` 包含 `Elapsed Virtual Time` 與 `State`。
+- `renode_command` 回傳 Renode 版本資訊。
+- `renode_stop` 回傳 `Renode stopped.`
+
+## 4. 嵌入式專案工作流程測試
+
+請 agent 產生 LED 呼吸燈專案：
+
+```text
+請使用 renode MCP，在 /tmp/led-breathing 建立 STM32F401RE 的 LED 呼吸燈專案：
+PA5、active-high、2 秒週期，UART 為 sysbus.usart2。
+接著呼叫 project_build 和 project_artifacts，列出產生的 ELF、BIN、HEX。
+```
+
+`project_create` 會建立程式碼骨架、Renode 情境和測試契約。`project_build` 可驗證建置流程；若使用主機 C compiler，產生的是 host ELF，**不能**載入 STM32 模擬器。
+
+要做完整模擬驗證，專案需要 CMSIS/HAL、startup code、linker script 與 `arm-none-eabi-gcc` toolchain，並產出 `EM_ARM`（machine type `40`）的 ELF。完成後要求 agent：
+
+```text
+請使用 renode_verify_project 驗證 /tmp/led-breathing 的 ARM ELF，
+回報載入的 firmware、模擬器狀態、virtual time 與 assertions。
+```
+
+## 5. GUI 與 UART Analyzer（選用）
+
+原生 GUI 需要 Renode 的 GTK/桌面相依套件。確認直接執行 Renode 可以開啟視窗後，在任何 agent host 的 `--renode ...` 後加入 `--show-ui`，再開啟新的 agent session。
+
+Codex CLI 的重新設定方式：
+
+```sh
+codex mcp remove renode
+# 重新執行第 2 步的 codex mcp add，並在 --renode ... 後加入 --show-ui
+```
+
+然後在新的 agent session 輸入：
+
+```text
+請啟動 Renode，載入定義 sysbus.usart2 的板級情境，並呼叫
+renode_open_uart_analyzer，peripheral 為 sysbus.usart2。
+```
+
+若未加 `--show-ui`，MCP 仍可執行模擬和讀取 UART/monitor 資訊，但不會顯示原生 Analyzer 視窗。
+
+目前 UART Analyzer 視窗供人員觀察；MCP 尚未提供擷取視窗畫面或將 UART 文字串流回 agent 的專屬工具。
+
+## 目前限制
+
+- `project_create` 只建立與 toolchain 無關的 CMake 骨架；它不會從 datasheet 產生 HAL/CMSIS、startup code、linker script 或完整板級週邊模型。
+- `datasheet` 欄位只記錄本機檔案路徑並回報是否存在，不會解析 datasheet。
+- 使用主機編譯器的 `project_build` 只會產生 host ELF；STM32 驗證需要 `arm-none-eabi` toolchain 與 `EM_ARM` ELF。
+- `renode_verify_project` 檢查 ELF 架構、載入韌體、啟動模擬並回傳 assertions；它**不會執行 assertions，也不會證明 GPIO/PWM 行為正確**。
+- 仍須提供正確的板級 `.repl`/`.resc`。Renode 模擬不能取代最終的 HIL 測試、實體板測試或燒錄流程。
+
+## 可用工具
+
+| 工具 | 用途 |
+| --- | --- |
+| `project_create` | 建立韌體、Renode scenario 與測試契約。 |
+| `project_build` | 執行建置並找出 ELF/BIN/HEX。 |
+| `project_artifacts` | 列出 firmware artifacts。 |
+| `renode_start` / `renode_stop` | 管理 Renode session。 |
+| `renode_load_elf` | 將 ARM ELF 載入目前 machine。 |
+| `renode_verify_project` / `renode_run_project` | 載入 ARM ELF、啟動模擬並回傳報告。 |
+| `renode_system_info` | 取得 virtual time 與狀態。 |
+| `renode_command` | 執行允許的 Renode monitor 指令。 |
+| `renode_open_uart_analyzer` | 開啟原生 UART Analyzer，需要 GUI。 |
+
+## 本機開發測試
+
+在 Renode repository 根目錄執行：
+
+```sh
+python3 -m unittest discover -s tools/renode_mcp_server -p 'test_*.py'
+```
+
+## 疑難排解
+
+- `renode` 不在 PATH：將 `--renode` 指向 Renode 的絕對路徑。
+- 找不到 .NET runtime：設定 `DOTNET_ROOT`，並將其加入 MCP 的 `PATH`。
+- `could not reserve a local Renode monitor port`：確認本機安全軟體沒有封鎖 loopback TCP，並停止殘留的 Renode process。
+- GUI 自動退回 console：先使用 headless 模式；之後安裝 Renode 所需的 GTK/桌面相依套件，再使用 `--show-ui`。
+- `renode_verify_project` 拒絕 ELF：請使用 ARM 交叉編譯器，而非主機編譯器。

--- a/tools/renode_mcp_server/__init__.py
+++ b/tools/renode_mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""MCP bridge for controlling a Renode monitor instance."""

--- a/tools/renode_mcp_server/codex.renode.toml.example
+++ b/tools/renode_mcp_server/codex.renode.toml.example
@@ -1,0 +1,12 @@
+[mcp_servers.renode]
+command = "/usr/bin/python3"
+args = ["/ABSOLUTE/PATH/TO/renode/tools/renode_mcp_server/server.py", "--renode", "/ABSOLUTE/PATH/TO/renode/renode"]
+cwd = "/ABSOLUTE/PATH/TO/renode"
+enabled = true
+startup_timeout_sec = 30
+tool_timeout_sec = 120
+enabled_tools = ["project_create", "project_build", "project_artifacts", "renode_start", "renode_load_elf", "renode_verify_project", "renode_run_project", "renode_system_info", "renode_open_uart_analyzer", "renode_command", "renode_stop"]
+
+[mcp_servers.renode.env]
+DOTNET_ROOT = "/ABSOLUTE/PATH/TO/dotnet"
+PATH = "/ABSOLUTE/PATH/TO/dotnet:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"

--- a/tools/renode_mcp_server/server.py
+++ b/tools/renode_mcp_server/server.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Expose a Renode monitor as an MCP server over stdio.
+
+The bridge starts Renode with its documented ``-P`` monitor TCP endpoint and
+serializes requests because a monitor connection is stateful.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pty
+import re
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from workflow import EmbeddedProject, WorkflowError
+
+
+MAX_COMMAND_LENGTH = 4096
+MAX_SCRIPT_BYTES = 4 * 1024 * 1024
+PROMPT = re.compile(rb"(?:^|\r?\n)\([^\r\n()]{0,128}\) ?$")
+PERIPHERAL_NAME = re.compile(r"^[A-Za-z0-9_.-]{1,256}$")
+
+
+class RenodeError(RuntimeError):
+    """An expected failure while talking to Renode."""
+
+
+def _find_prompt(data: bytes) -> Optional[int]:
+    match = PROMPT.search(data)
+    return match.start() if match else None
+
+
+def _validate_command(command: str) -> str:
+    if not isinstance(command, str) or not command.strip():
+        raise RenodeError("command must be a non-empty string")
+    if len(command) > MAX_COMMAND_LENGTH:
+        raise RenodeError(f"command exceeds {MAX_COMMAND_LENGTH} characters")
+    return command.strip()
+
+
+def _validate_peripheral_name(name: str) -> str:
+    if not isinstance(name, str) or not PERIPHERAL_NAME.fullmatch(name):
+        raise RenodeError("peripheral must contain only letters, numbers, underscores, dots, or hyphens")
+    return name
+
+
+def _strip_telnet_commands(data: bytes) -> bytes:
+    output = bytearray()
+    index = 0
+    while index < len(data):
+        if data[index] != 255:
+            output.append(data[index])
+            index += 1
+            continue
+        if index + 1 >= len(data):
+            break
+        command = data[index + 1]
+        if command == 255:
+            output.append(command)
+            index += 2
+        elif command == 250:
+            terminator = data.find(b"\xff\xf0", index + 2)
+            index = len(data) if terminator == -1 else terminator + 2
+        else:
+            index += 3
+    return bytes(output)
+
+
+class RenodeSession:
+    def __init__(self, executable: str, startup_script: Optional[str], timeout: float, headless: bool = True):
+        self.executable = executable
+        self.startup_script = startup_script
+        self.timeout = timeout
+        self.headless = headless
+        self.process: subprocess.Popen[bytes] | None = None
+        self.connection: socket.socket | None = None
+        self.console_pty_master: Optional[int] = None
+        self.lock = threading.Lock()
+
+    def start(self) -> None:
+        if self.process and self.process.poll() is None:
+            return
+        try:
+            with socket.socket() as probe:
+                probe.bind(("127.0.0.1", 0))
+                port = probe.getsockname()[1]
+        except OSError as error:
+            raise RenodeError(f"could not reserve a local Renode monitor port: {error}") from error
+
+        command = [self.executable, "--plain", "-P", str(port)]
+        if self.headless:
+            command[1:1] = ["--disable-gui", "--hide-log"]
+        if self.startup_script:
+            script = Path(self.startup_script).expanduser().resolve()
+            if not script.is_file():
+                raise RenodeError(f"startup script does not exist: {script}")
+            if script.stat().st_size > MAX_SCRIPT_BYTES:
+                raise RenodeError("startup script is too large")
+            command.append(str(script))
+
+        slave_pty = None
+        try:
+            self.console_pty_master, slave_pty = pty.openpty()
+            self.process = subprocess.Popen(command, stdin=slave_pty, stdout=slave_pty, stderr=subprocess.PIPE, close_fds=True)
+        except OSError as error:
+            if self.console_pty_master is not None:
+                os.close(self.console_pty_master)
+                self.console_pty_master = None
+            raise RenodeError(f"could not start Renode: {error}") from error
+        finally:
+            if slave_pty is not None:
+                os.close(slave_pty)
+
+        deadline = time.monotonic() + self.timeout
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                details = self.process.stderr.read().decode(errors="replace")[-1000:] if self.process.stderr else ""
+                raise RenodeError(f"Renode exited during startup: {details}")
+            try:
+                self.connection = socket.create_connection(("127.0.0.1", port), timeout=0.25)
+                self.connection.settimeout(self.timeout)
+                return
+            except OSError:
+                time.sleep(0.05)
+        self.stop()
+        raise RenodeError("timed out waiting for Renode monitor")
+
+    def load_startup_script(self, script: str) -> None:
+        resolved_script = str(Path(script).expanduser().resolve())
+        if self.startup_script != resolved_script:
+            self.stop()
+            self.startup_script = resolved_script
+        self.start()
+
+    def stop(self) -> None:
+        if self.connection:
+            self.connection.close()
+            self.connection = None
+        if self.console_pty_master is not None:
+            os.close(self.console_pty_master)
+            self.console_pty_master = None
+        if self.process and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait()
+        self.process = None
+
+    def command(self, command: str) -> str:
+        command = _validate_command(command)
+        with self.lock:
+            self.start()
+            if not self.connection:
+                raise RenodeError("Renode monitor is not connected")
+            try:
+                self.connection.sendall(command.encode() + b"\n")
+                return self._read_response().strip()
+            except (OSError, TimeoutError) as error:
+                self.stop()
+                raise RenodeError(f"Renode monitor connection failed: {error}") from error
+
+    def _read_response(self) -> str:
+        if not self.connection:
+            raise RenodeError("Renode monitor is not connected")
+        data = bytearray()
+        deadline = time.monotonic() + self.timeout
+        while time.monotonic() < deadline:
+            prompt_start = _find_prompt(bytes(data))
+            if prompt_start is not None:
+                return _strip_telnet_commands(bytes(data[:prompt_start])).decode(errors="replace")
+            try:
+                chunk = self.connection.recv(4096)
+            except socket.timeout:
+                continue
+            if not chunk:
+                raise RenodeError("Renode closed the monitor connection")
+            data.extend(chunk)
+        raise RenodeError("timed out waiting for Renode monitor response")
+
+
+TOOLS = [
+    {"name": "project_create", "description": "Create an embedded project from a board and requirements manifest.", "inputSchema": {"type": "object", "properties": {"project_dir": {"type": "string"}, "manifest": {"type": "object"}}, "required": ["project_dir", "manifest"], "additionalProperties": False}},
+    {"name": "project_build", "description": "Build a generated project and list ELF/BIN/HEX artifacts.", "inputSchema": {"type": "object", "properties": {"project_dir": {"type": "string"}, "command": {"type": "string"}}, "required": ["project_dir"], "additionalProperties": False}},
+    {"name": "project_artifacts", "description": "List generated firmware artifacts in a project build directory.", "inputSchema": {"type": "object", "properties": {"project_dir": {"type": "string"}}, "required": ["project_dir"], "additionalProperties": False}},
+    {"name": "renode_start", "description": "Start Renode, optionally loading a local .resc script.", "inputSchema": {"type": "object", "properties": {"script": {"type": "string", "description": "Local Renode .resc file path."}}, "additionalProperties": False}},
+    {"name": "renode_load_elf", "description": "Load an ARM ELF from a generated project into the running Renode machine.", "inputSchema": {"type": "object", "properties": {"project_dir": {"type": "string"}, "elf": {"type": "string", "description": "Project-relative ELF path when more than one exists."}}, "required": ["project_dir"], "additionalProperties": False}},
+    {"name": "renode_verify_project", "description": "Load an ARM firmware ELF, start Renode, and return a structured simulation verification report.", "inputSchema": {"type": "object", "properties": {"project_dir": {"type": "string"}, "elf": {"type": "string", "description": "Project-relative ELF path when more than one exists."}}, "required": ["project_dir"], "additionalProperties": False}},
+    {"name": "renode_run_project", "description": "Alias for renode_verify_project.", "inputSchema": {"type": "object", "properties": {"project_dir": {"type": "string"}, "elf": {"type": "string"}}, "required": ["project_dir"], "additionalProperties": False}},
+    {"name": "renode_system_info", "description": "Return the current Renode virtual-time and emulation status.", "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False}},
+    {"name": "renode_open_uart_analyzer", "description": "Open Renode's native UART analyzer window for a UART peripheral.", "inputSchema": {"type": "object", "properties": {"peripheral": {"type": "string", "description": "UART peripheral name, e.g. sysbus.usart2."}}, "additionalProperties": False}},
+    {"name": "renode_command", "description": "Execute one Renode monitor command and return its textual output.", "inputSchema": {"type": "object", "properties": {"command": {"type": "string", "description": "A Renode monitor command."}}, "required": ["command"], "additionalProperties": False}},
+    {"name": "renode_stop", "description": "Stop the managed Renode process.", "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False}},
+]
+
+
+class McpServer:
+    def __init__(self, session: RenodeSession):
+        self.session = session
+
+    def handle(self, request: dict[str, Any]) -> dict[str, Any] | None:
+        request_id = request.get("id")
+        method = request.get("method")
+        if method == "notifications/initialized":
+            return None
+        if method == "ping":
+            return {"jsonrpc": "2.0", "id": request_id, "result": {}}
+        if method == "initialize":
+            return {"jsonrpc": "2.0", "id": request_id, "result": {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "renode-mcp", "version": "0.1.0"}}}
+        if method == "tools/list":
+            return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": TOOLS}}
+        if method == "tools/call":
+            return self._call_tool(request_id, request.get("params") or {})
+        if request_id is None:
+            return None
+        return {"jsonrpc": "2.0", "id": request_id, "error": {"code": -32601, "message": f"method not found: {method}"}}
+
+    def _call_tool(self, request_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+        name = params.get("name")
+        arguments = params.get("arguments") or {}
+        try:
+            if name == "project_create":
+                project = EmbeddedProject(Path(arguments["project_dir"]))
+                text = json.dumps(project.create(arguments["manifest"]), indent=2)
+            elif name == "project_build":
+                project = EmbeddedProject(Path(arguments["project_dir"]))
+                text = json.dumps(project.build(arguments.get("command")), indent=2)
+            elif name == "project_artifacts":
+                project = EmbeddedProject(Path(arguments["project_dir"]))
+                text = json.dumps({"project": str(project.root), "artifacts": project.artifacts()}, indent=2)
+            elif name == "renode_start":
+                if "script" in arguments:
+                    self.session.load_startup_script(arguments["script"])
+                else:
+                    self.session.start()
+                text = "Renode is running."
+            elif name == "renode_load_elf":
+                project = EmbeddedProject(Path(arguments["project_dir"]))
+                elf = project.firmware_elf(arguments.get("elf"))
+                text = self.session.command(f"sysbus LoadELF @{elf['path']}")
+            elif name in {"renode_run_project", "renode_verify_project"}:
+                project = EmbeddedProject(Path(arguments["project_dir"]))
+                script = project.root / "renode/board.resc"
+                if not script.is_file():
+                    raise WorkflowError("project has no renode/board.resc")
+                elf = project.firmware_elf(arguments.get("elf"))
+                self.session.load_startup_script(str(script))
+                load_output = self.session.command(f"sysbus LoadELF @{elf['path']}")
+                start_output = self.session.command("start")
+                time_output = self.session.command("emulation GetTimeSourceInfo")
+                text = json.dumps({
+                    "project": str(project.root),
+                    "firmware": elf,
+                    "simulation": {
+                        "status": "started",
+                        "load_output": load_output,
+                        "start_output": start_output,
+                        "time_source": time_output,
+                    },
+                    "assertions": project.test_spec().get("assertions", []),
+                }, indent=2)
+            elif name == "renode_system_info":
+                text = json.dumps({"time_source": self.session.command("emulation GetTimeSourceInfo")}, indent=2)
+            elif name == "renode_open_uart_analyzer":
+                peripheral = _validate_peripheral_name(arguments.get("peripheral", "sysbus.usart2"))
+                text = self.session.command(f"showAnalyzer {peripheral}")
+            elif name == "renode_command":
+                text = self.session.command(arguments.get("command"))
+            elif name == "renode_stop":
+                self.session.stop()
+                text = "Renode stopped."
+            else:
+                raise RenodeError(f"unknown tool: {name}")
+            return {"jsonrpc": "2.0", "id": request_id, "result": {"content": [{"type": "text", "text": text}]}}
+        except (RenodeError, WorkflowError, TypeError, ValueError, KeyError) as error:
+            return {"jsonrpc": "2.0", "id": request_id, "result": {"isError": True, "content": [{"type": "text", "text": str(error)}]}}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--renode", default=os.environ.get("RENODE_EXECUTABLE", "renode"), help="Renode executable")
+    parser.add_argument("--timeout", type=float, default=10.0, help="Monitor startup/response timeout in seconds")
+    parser.add_argument("--show-ui", action="store_true", help="Keep Renode's native UI visible instead of running headless")
+    args = parser.parse_args()
+    session = RenodeSession(args.renode, None, args.timeout, headless=not args.show_ui)
+    server = McpServer(session)
+    try:
+        for line in sys.stdin:
+            if not line.strip():
+                continue
+            try:
+                request = json.loads(line)
+                response = server.handle(request)
+            except (json.JSONDecodeError, TypeError) as error:
+                response = {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": str(error)}}
+            if response is not None:
+                sys.stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+                sys.stdout.flush()
+    finally:
+        session.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/renode_mcp_server/test_server.py
+++ b/tools/renode_mcp_server/test_server.py
@@ -1,0 +1,132 @@
+import unittest
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from server import McpServer, RenodeError, RenodeSession, _find_prompt, _strip_telnet_commands, _validate_command, _validate_peripheral_name
+from workflow import EmbeddedProject, WorkflowError
+
+
+class ServerHelpersTest(unittest.TestCase):
+    def test_find_prompt_at_end(self):
+        self.assertEqual(_find_prompt(b"ok\r\n(monitor) "), 2)
+
+    def test_find_prompt_accepts_machine_name(self):
+        self.assertIsNotNone(_find_prompt(b"output\n(my_machine) "))
+
+    def test_find_prompt_rejects_non_terminal_prompt(self):
+        self.assertIsNone(_find_prompt(b"(monitor) output"))
+
+    def test_validate_command(self):
+        self.assertEqual(_validate_command("  version  "), "version")
+        with self.assertRaises(Exception):
+            _validate_command(" ")
+
+    def test_validate_peripheral_name(self):
+        self.assertEqual(_validate_peripheral_name("sysbus.usart2"), "sysbus.usart2")
+        with self.assertRaises(RenodeError):
+            _validate_peripheral_name("sysbus.usart2; quit")
+
+    def test_strip_telnet_commands(self):
+        self.assertEqual(_strip_telnet_commands(b"\xff\xfd\x1f\xff\xfb\x01Renode"), b"Renode")
+
+    def test_session_reports_unavailable_loopback_port(self):
+        with mock.patch("server.socket.socket", side_effect=OSError("blocked")):
+            with self.assertRaisesRegex(RenodeError, "could not reserve"):
+                RenodeSession("renode", None, 1).start()
+
+    def test_session_reports_unavailable_pseudo_terminal(self):
+        with mock.patch("server.socket.socket") as socket_factory, mock.patch("server.pty.openpty", side_effect=OSError("blocked")):
+            socket_factory.return_value.__enter__.return_value.getsockname.return_value = ("127.0.0.1", 12345)
+            with self.assertRaisesRegex(RenodeError, "could not start Renode"):
+                RenodeSession("renode", None, 1).start()
+
+
+class WorkflowTest(unittest.TestCase):
+    def test_create_project_and_list_artifacts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            project = EmbeddedProject(Path(directory) / "breathing")
+            result = project.create({
+                "name": "led_breathing",
+                "board": {"mcu": "STM32F401RE", "datasheet": "/missing/datasheet.pdf"},
+                "requirements": {"led_gpio": "PA5", "breath_period_ms": 2000},
+            })
+            self.assertIn("src/main.c", result["files"])
+            self.assertFalse(result["datasheet"]["exists"])
+            self.assertEqual(project.test_spec()["name"], "led_breathing")
+            self.assertEqual(project.artifacts(), [])
+
+    def test_firmware_elf_requires_arm_binary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            project = self._create_project(Path(directory))
+            elf = project.root / "build/firmware.elf"
+            elf.parent.mkdir()
+            elf.write_bytes(b"\x7fELF\x01\x01" + b"\x00" * 12 + b"\x28\x00")
+            self.assertEqual(project.firmware_elf()["machine_name"], "ARM")
+            elf.write_bytes(b"\x7fELF\x02\x01" + b"\x00" * 12 + b"\x3e\x00")
+            with self.assertRaises(WorkflowError):
+                project.firmware_elf()
+
+    def test_manifest_requires_led_gpio(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(WorkflowError):
+                EmbeddedProject(Path(directory)).create({"name": "bad", "board": {"mcu": "STM32F4"}})
+
+    @staticmethod
+    def _create_project(root):
+        project = EmbeddedProject(root / "breathing")
+        project.create({
+            "name": "led_breathing",
+            "board": {"mcu": "STM32F401RE"},
+            "requirements": {"led_gpio": "PA5"},
+        })
+        return project
+
+
+class McpVerificationTest(unittest.TestCase):
+    def test_verify_project_loads_arm_elf_and_starts_emulation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            project = WorkflowTest._create_project(Path(directory))
+            elf = project.root / "build/firmware.elf"
+            elf.parent.mkdir()
+            elf.write_bytes(b"\x7fELF\x01\x01" + b"\x00" * 12 + b"\x28\x00")
+            session = FakeSession()
+            response = McpServer(session).handle({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "renode_verify_project", "arguments": {"project_dir": str(project.root)}},
+            })
+            report = json.loads(response["result"]["content"][0]["text"])
+            self.assertEqual(report["firmware"]["machine_name"], "ARM")
+            self.assertEqual(session.commands, [f"sysbus LoadELF @{elf}", "start", "emulation GetTimeSourceInfo"])
+
+    def test_system_info_and_uart_analyzer(self):
+        session = FakeSession()
+        server = McpServer(session)
+        info_response = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "renode_system_info", "arguments": {}}})
+        analyzer_response = server.handle({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "renode_open_uart_analyzer", "arguments": {"peripheral": "sysbus.usart2"}}})
+        self.assertEqual(json.loads(info_response["result"]["content"][0]["text"])["time_source"], "ok")
+        self.assertEqual(analyzer_response["result"]["content"][0]["text"], "ok")
+        self.assertEqual(session.commands, ["emulation GetTimeSourceInfo", "showAnalyzer sysbus.usart2"])
+
+
+class FakeSession:
+    def __init__(self):
+        self.commands = []
+        self.startup_script = None
+
+    def load_startup_script(self, script):
+        self.startup_script = script
+
+    def command(self, command):
+        self.commands.append(command)
+        return "ok"
+
+    def stop(self):
+        return None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/renode_mcp_server/workflow.py
+++ b/tools/renode_mcp_server/workflow.py
@@ -1,0 +1,271 @@
+"""Project and verification workflow used by the Renode MCP server."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import struct
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class WorkflowError(RuntimeError):
+    """An invalid project request or workflow failure."""
+
+
+ELF_MACHINE_NAMES = {
+    40: "ARM",
+    183: "AArch64",
+}
+
+
+def _safe_path(path: str, root: Path) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    candidate = candidate.resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as error:
+        raise WorkflowError("path must remain inside the project directory") from error
+    return candidate
+
+
+class ProjectManifest:
+    def __init__(self, data: Dict[str, Any]):
+        board = data.get("board") or {}
+        requirements = data.get("requirements") or {}
+        self.name = self._required_string(data, "name", "project")
+        self.board = board
+        self.requirements = requirements
+        self.mcu = self._required_string(board, "mcu", "board.mcu")
+        self.datasheet = board.get("datasheet")
+        if self.datasheet is not None and not isinstance(self.datasheet, str):
+            raise WorkflowError("board.datasheet must be a local file path")
+        self.cpu_platform = board.get("renode_platform", "platforms/cpus/stm32f4.repl")
+        self.elf_machine = int(board.get("elf_machine", 40))
+        self.led_gpio = self._required_string(requirements, "led_gpio", "requirements.led_gpio")
+        self.led_active_high = bool(requirements.get("led_active_high", True))
+        self.breath_period_ms = int(requirements.get("breath_period_ms", 2000))
+        self.uart = requirements.get("uart", "sysbus.usart2")
+        if self.breath_period_ms < 100:
+            raise WorkflowError("requirements.breath_period_ms must be at least 100")
+
+    @staticmethod
+    def _required_string(data: Dict[str, Any], key: str, label: str) -> str:
+        value = data.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise WorkflowError(f"{label} must be a non-empty string")
+        return value.strip()
+
+    @classmethod
+    def load(cls, path: Path) -> "ProjectManifest":
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as error:
+            raise WorkflowError(f"could not read manifest: {error}") from error
+        if not isinstance(data, dict):
+            raise WorkflowError("manifest must contain a JSON object")
+        return cls(data)
+
+
+class EmbeddedProject:
+    def __init__(self, root: Path):
+        self.root = root.resolve()
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.root / "manifest.json"
+
+    def create(self, manifest_data: Dict[str, Any]) -> Dict[str, Any]:
+        manifest = ProjectManifest(manifest_data)
+        self.root.mkdir(parents=True, exist_ok=True)
+        files = {
+            "manifest.json": json.dumps(manifest_data, indent=2) + "\n",
+            "README.md": self._readme(manifest),
+            "CMakeLists.txt": self._cmake(manifest),
+            "src/main.c": self._main_c(manifest),
+            "include/app_config.h": self._config_h(manifest),
+            "renode/board.resc": self._resc(manifest),
+            "tests/led_breathing.json": self._test_spec(manifest),
+        }
+        for relative, content in files.items():
+            destination = _safe_path(relative, self.root)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(content)
+        result = {"project": str(self.root), "files": sorted(files), "manifest": manifest_data}
+        if manifest.datasheet:
+            datasheet = Path(manifest.datasheet).expanduser().resolve()
+            result["datasheet"] = {"path": str(datasheet), "exists": datasheet.is_file()}
+        return result
+
+    def build(self, command: Optional[str] = None, timeout: int = 120) -> Dict[str, Any]:
+        if not self.manifest_path.is_file():
+            raise WorkflowError("project has no manifest.json")
+        build_command = command or os.environ.get("RENODE_MCP_BUILD_COMMAND", "cmake -S . -B build && cmake --build build")
+        commands = [part.strip() for part in build_command.split("&&")]
+        if not commands or any(not part for part in commands):
+            raise WorkflowError("build command must contain one or more commands separated by &&")
+        stdout = []
+        stderr = []
+        returncode = 0
+        try:
+            for command_part in commands:
+                argv = shlex.split(command_part)
+                if not argv or any(token in {";", "&&", "||", "|", ">", "<"} for token in argv):
+                    raise WorkflowError("build command contains an unsupported shell operator")
+                result = subprocess.run(argv, cwd=self.root, capture_output=True, text=True, timeout=timeout, check=False)
+                stdout.append(result.stdout)
+                stderr.append(result.stderr)
+                returncode = result.returncode
+                if returncode != 0:
+                    break
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise WorkflowError(f"build failed to start or timed out: {error}") from error
+        return {"success": returncode == 0, "returncode": returncode, "stdout": "".join(stdout)[-12000:], "stderr": "".join(stderr)[-12000:], "artifacts": self.artifacts()}
+
+    def artifacts(self) -> List[str]:
+        candidates = []
+        for path in self.root.glob("build/**/*"):
+            if path.is_file() and "CMakeFiles" not in path.parts and path.suffix.lower() in {".elf", ".bin", ".hex", ".map"}:
+                candidates.append(str(path.relative_to(self.root)))
+        return sorted(candidates)
+
+    def firmware_elf(self, requested_elf: Optional[str] = None) -> Dict[str, Any]:
+        if requested_elf:
+            elf = _safe_path(requested_elf, self.root)
+            if not elf.is_file():
+                raise WorkflowError(f"ELF does not exist: {elf}")
+        else:
+            candidates = [self.root / artifact for artifact in self.artifacts() if artifact.lower().endswith(".elf")]
+            if not candidates:
+                raise WorkflowError("no ELF artifact found; build the project with an embedded toolchain first")
+            if len(candidates) != 1:
+                raise WorkflowError("multiple ELF artifacts found; pass elf explicitly")
+            elf = candidates[0]
+
+        details = inspect_elf(elf)
+        manifest = ProjectManifest.load(self.manifest_path)
+        if details["machine"] != manifest.elf_machine:
+            expected = ELF_MACHINE_NAMES.get(manifest.elf_machine, str(manifest.elf_machine))
+            actual = details["machine_name"]
+            raise WorkflowError(f"ELF architecture is {actual}; expected {expected} for {manifest.mcu}")
+        details["path"] = str(elf)
+        details["relative_path"] = str(elf.relative_to(self.root))
+        return details
+
+    def test_spec(self) -> Dict[str, Any]:
+        path = self.root / "tests/led_breathing.json"
+        if not path.is_file():
+            raise WorkflowError("project has no led breathing test specification")
+        return json.loads(path.read_text())
+
+    @staticmethod
+    def _cmake(manifest: ProjectManifest) -> str:
+        return f'''cmake_minimum_required(VERSION 3.15)
+project({manifest.name} C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+add_executable(${{PROJECT_NAME}} src/main.c)
+target_include_directories(${{PROJECT_NAME}} PRIVATE include)
+set_target_properties(${{PROJECT_NAME}} PROPERTIES SUFFIX ".elf")
+message(STATUS "Cross-compile this template with an STM32 HAL/CMSIS toolchain")
+'''
+
+    @staticmethod
+    def _config_h(manifest: ProjectManifest) -> str:
+        gpio = manifest.led_gpio.replace("-", "_")
+        return f'''#pragma once
+
+#define APP_MCU "{manifest.mcu}"
+#define APP_LED_GPIO "{gpio}"
+#define APP_LED_ACTIVE_HIGH {1 if manifest.led_active_high else 0}
+#define APP_BREATH_PERIOD_MS {manifest.breath_period_ms}
+'''
+
+    @staticmethod
+    def _main_c(manifest: ProjectManifest) -> str:
+        return '''#include "app_config.h"
+#include <stdint.h>
+
+static void board_init(void);
+static void pwm_set_duty(uint32_t duty_percent);
+static void delay_ms(uint32_t milliseconds);
+
+int main(void) {
+    board_init();
+    for (;;) {
+        for (uint32_t duty = 0; duty <= 100; ++duty) {
+            pwm_set_duty(duty);
+            delay_ms(APP_BREATH_PERIOD_MS / 200);
+        }
+        for (uint32_t duty = 100; duty > 0; --duty) {
+            pwm_set_duty(duty);
+            delay_ms(APP_BREATH_PERIOD_MS / 200);
+        }
+    }
+}
+
+static void board_init(void) {
+}
+
+static void pwm_set_duty(uint32_t duty_percent) {
+    (void)duty_percent;
+}
+
+static void delay_ms(uint32_t milliseconds) {
+    (void)milliseconds;
+}
+'''
+
+    @staticmethod
+    def _resc(manifest: ProjectManifest) -> str:
+        return f'''mach create
+machine LoadPlatformDescription @{manifest.cpu_platform}
+showAnalyzer {manifest.uart}
+'''
+
+    @staticmethod
+    def _test_spec(manifest: ProjectManifest) -> str:
+        return json.dumps({"name": "led_breathing", "duration_ms": manifest.breath_period_ms * 2, "assertions": [{"gpio": manifest.led_gpio, "minimum_transitions": 10}, {"pwm_period_ms": manifest.breath_period_ms, "tolerance_percent": 5}]}, indent=2) + "\n"
+
+    @staticmethod
+    def _readme(manifest: ProjectManifest) -> str:
+        return f'''# {manifest.name}
+
+Generated embedded project for `{manifest.mcu}`.
+
+- LED GPIO: `{manifest.led_gpio}`
+- Breathing period: `{manifest.breath_period_ms} ms`
+- Renode platform: `{manifest.cpu_platform}`
+
+The source is a portable application skeleton. Add the board vendor HAL/CMSIS
+startup, linker script, and cross compiler configuration before a production
+flash. The Renode scenario is in `renode/board.resc` and the verification
+contract is in `tests/led_breathing.json`.
+'''
+
+
+def inspect_elf(path: Path) -> Dict[str, Any]:
+    try:
+        header = path.read_bytes()[:20]
+    except OSError as error:
+        raise WorkflowError(f"could not read ELF: {error}") from error
+    if len(header) < 20 or header[:4] != b"\x7fELF":
+        raise WorkflowError(f"not an ELF file: {path}")
+    data_encoding = header[5]
+    if data_encoding == 1:
+        byte_order = "<"
+    elif data_encoding == 2:
+        byte_order = ">"
+    else:
+        raise WorkflowError("ELF has an unsupported byte order")
+    machine = struct.unpack(f"{byte_order}H", header[18:20])[0]
+    return {
+        "class": 32 if header[4] == 1 else 64 if header[4] == 2 else "unknown",
+        "machine": machine,
+        "machine_name": ELF_MACHINE_NAMES.get(machine, f"machine-{machine}"),
+    }


### PR DESCRIPTION
### Related issue

Closes #975

### Description

This PR adds a new experimental local stdio Model Context Protocol (MCP) server under `tools/renode_mcp_server`.

This is a new feature/improvement that allows any MCP-compatible AI agent host to:

- start and stop a managed Renode session;
- load a local `.resc` platform script;
- execute Renode monitor commands;
- inspect virtual time and emulator state;
- load and validate ARM ELF artifacts;
- open a UART analyzer when native UI support is enabled;
- create and build a small embedded project scaffold.

The MCP server reuses Renode's existing monitor TCP mode. The monitor is bound only to `127.0.0.1`, while the MCP transport is newline-delimited JSON-RPC over stdio. No network MCP endpoint is exposed.

### Usage example

This contribution is a tool integration rather than a board-model bug, so there is no failing board-specific `.resc`/ELF case to put in the issue reproduction template. The implementation includes unit tests and a complete reproducible smoke test.

Run the unit tests from the Renode repository root:

```sh
python3 -m unittest discover -s tools/renode_mcp_server -p 'test_*.py'
```

Configure any stdio-compatible MCP host to execute:

```text
command: /usr/bin/python3
args:
  - /absolute/path/to/renode/tools/renode_mcp_server/server.py
  - --renode
  - /absolute/path/to/renode/renode
```

Then ask the agent to call, in order:

1. `renode_start`
2. `renode_system_info`
3. `renode_command` with `command: "version"`
4. `renode_stop`

Expected output includes the Renode version, elapsed virtual time, emulator state, and successful shutdown. Board/firmware, project-generation, and GUI/UART examples are documented in `tools/renode_mcp_server/README.md`.

### Additional information

Validation environment:

- macOS 13.7.8, x86_64
- Renode v1.16.1, build `1.16.1+20260822`
- .NET 10.0.11
- Python 3.9.6

Validation results:

- 13 unit tests pass.
- A real Renode process starts through the stdio MCP server.
- `renode_system_info` returns virtual-time information and `State: Idle`.
- The managed Renode process stops successfully.
- The PR has no merge conflicts with `master`.

Current limitations are documented in the README. In particular, datasheets are not parsed, ARM firmware and board-specific `.repl`/`.resc` files remain user-provided, generated assertions are not executed, and Renode simulation does not replace final hardware-in-the-loop testing.

The feature branch was created before issue #975 existed. GitHub closes an open PR when its head branch is renamed, so the existing `renode-mcp-server` branch name is intentionally retained. The commit message follows the required issue-linked format.
