### PR TITLE
renode: configure DOTNET_ROOT in launcher script

### DIFF
--- a/renode
+++ b/renode
@@ -75,4 +75,10 @@ else
     RENODE_DLL="$RENODE_DIR/Renode.dll"
 fi
 
-${TRACE_COMMAND} dotnet "$RENODE_DLL" "${PARAMS[@]:-}"
+DOTNET_BIN="dotnet"
+if [ -x "$HOME/.dotnet/dotnet" ]; then
+    DOTNET_BIN="$HOME/.dotnet/dotnet"
+    export DOTNET_ROOT="$HOME/.dotnet"
+fi
+
+${TRACE_COMMAND} "$DOTNET_BIN" "$RENODE_DLL" "${PARAMS[@]:-}"


### PR DESCRIPTION
### Description

This improvement updates the `renode` launcher script to automatically detect `$HOME/.dotnet/dotnet` and export `DOTNET_ROOT="$HOME/.dotnet"` when executing the Renode runner script. This ensures user-installed .NET SDK and runtimes located in the default `~/.dotnet` directory are properly resolved.

### Additional information

Tested on Linux with user-local .NET SDK installation.