### PR TITLE
platforms: add NVMC and UICR memory regions to nrf52840.repl

### DIFF
--- a/platforms/cpus/nrf52840.repl
+++ b/platforms/cpus/nrf52840.repl
@@ -30,8 +30,13 @@ wdt: Timers.NRF52840_Watchdog @ sysbus 0x40010000
 
 ppi: Miscellaneous.NRF52840_PPI @ sysbus 0x4001F000
 
+nvmc: Miscellaneous.NRF52840_NVMC @ sysbus 0x4001E000
+
 flash: Memory.MappedMemory @ sysbus 0x0
     size: 0x100000
+
+uicr: Memory.MappedMemory @ sysbus 0x10001000
+    size: 0x1000
 
 ram: Memory.MappedMemory @ { sysbus 0x800000; sysbus 0x20000000 }
     size: 0x40000


### PR DESCRIPTION
### Description

This PR adds the missing NVMC peripheral model and UICR memory region to `platforms/cpus/nrf52840.repl`:
- Maps `Miscellaneous.NRF52840_NVMC` at `sysbus 0x4001E000`
- Maps the UICR (User Information Configuration Registers) memory region (`Memory.MappedMemory`) at `sysbus 0x10001000` with size `0x1000`

### Additional information

These additions allow firmware (e.g. Zephyr, Nordic SDK) targeting nRF52840 that configures flash/UICR or interacts with the NVMC controller to run without bus aborts or unhandled memory accesses.