### PR TITLE
Silicon Labs: rename and improve USART_0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/Infrastructure"]
 	path = src/Infrastructure
-	url = https://github.com/renode/renode-infrastructure.git
+	url = https://github.com/SiliconLabsSoftware/renode-infrastructure.git
 [submodule "lib/termsharp"]
 	path = lib/termsharp
 	url = https://github.com/antmicro/termsharp.git

--- a/platforms/cpus/silabs/efr32s2/efr32mg24.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32mg24.repl
@@ -4,7 +4,7 @@ i2c0: I2C.EFR32_I2CController @ {
     }
     -> nvic@27
     
-usart0: UART.EFR32xG2_USART_0 @ {
+usart0: UART.SiLabs_USART_0 @ {
         sysbus <0x4005C000, +0x4000>; // USART0_S
         sysbus <0x5005C000, +0x4000>  // USART0_NS
     }

--- a/platforms/cpus/silabs/efr32s2/efr32mg26.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32mg26.repl
@@ -4,7 +4,7 @@ i2c0: I2C.EFR32_I2CController @ {
     }
     -> nvic@41
 
-usart0: UART.EFR32xG2_USART_0 @ {
+usart0: UART.SiLabs_USART_0 @ {
         sysbus <0x400A0000, +0x4000>; // USART0_S
         sysbus <0x500A0000, +0x4000>  // USART0_NS
     }

--- a/platforms/cpus/silabs/efr32s2/efr32xg22.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32xg22.repl
@@ -56,7 +56,7 @@ ldma: DMA.EFR32xG22_LDMA @ {
     }
     -> nvic@21
 
-usart0: UART.EFR32xG2_USART_0 @ {
+usart0: UART.SiLabs_USART_0 @ {
         sysbus <0x4005C000, +0x4000>; // USART0_S
         sysbus <0x5005C000, +0x4000>  // USART0_NS
     }
@@ -70,7 +70,7 @@ usart0: UART.EFR32xG2_USART_0 @ {
     TxBufferLowSingleRequest -> ldma@0x1042
     TxEmptyRequest -> ldma@0x0044
 
-usart1: UART.EFR32xG2_USART_0 @ {
+usart1: UART.SiLabs_USART_0 @ {
         sysbus <0x40060000, +0x4000>; // USART1_S
         sysbus <0x50060000, +0x4000>  // USART1_NS
     }


### PR DESCRIPTION
- Point platforms at the renamed SiLabs_USART_0 peripheral
- Keep clockFrequency constructor arguments unchanged