### PR TITLE
Silicon Labs: rename and improve EUSART_2

### DIFF
--- a/platforms/cpus/silabs/efr32s2/efr32mg24.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32mg24.repl
@@ -18,7 +18,7 @@ usart0: UART.EFR32xG2_USART_0 @ {
     TxBufferLowSingleRequest -> ldma@0x1042
     TxEmptyRequest -> ldma@0x0044
 
-eusart0: UART.EFR32xG2_EUSART_2 @ {
+eusart0: UART.SiLabs_EUSART_2 @ {
         sysbus <0x4B010000, +0x4000>; // EUSART0_S
         sysbus <0x5B010000, +0x4000>  // EUSART0_NS
     }
@@ -29,7 +29,7 @@ eusart0: UART.EFR32xG2_EUSART_2 @ {
     RxFifoLevelGpioSignal -> gpioPort@0x1202
     TxFifoLevel -> ldma@0x00F1
 
-eusart1: UART.EFR32xG2_EUSART_2 @ {
+eusart1: UART.SiLabs_EUSART_2 @ {
         sysbus <0x400A0000, +0x4000>; // EUSART1_S
         sysbus <0x500A0000, +0x4000>  // EUSART1_NS
     }

--- a/platforms/cpus/silabs/efr32s2/efr32mg26.repl
+++ b/platforms/cpus/silabs/efr32s2/efr32mg26.repl
@@ -18,7 +18,7 @@ usart0: UART.EFR32xG2_USART_0 @ {
     TxBufferLowSingleRequest -> ldma@0x1042
     TxEmptyRequest -> ldma@0x0044
 
-eusart0: UART.EFR32xG2_EUSART_2 @ {
+eusart0: UART.SiLabs_EUSART_2 @ {
         sysbus <0x4B010000, +0x4000>; // EUSART0_S
         sysbus <0x5B010000, +0x4000>  // EUSART0_NS
     }
@@ -29,7 +29,7 @@ eusart0: UART.EFR32xG2_EUSART_2 @ {
     RxFifoLevelGpioSignal -> gpioPort@0x1202
     TxFifoLevel -> ldma@0x00F1
 
-eusart1: UART.EFR32xG2_EUSART_2 @ {
+eusart1: UART.SiLabs_EUSART_2 @ {
         sysbus <0x4008C000, +0x4000>; // EUSART1_S
         sysbus <0x5008C000, +0x4000>  // EUSART1_NS
     }


### PR DESCRIPTION
- Rename EFR32xG2_EUSART_2 to SiLabs_EUSART_2
- Improve reset, RX DMA request pulsing, and deferred TX request restore