### PR TITLE
[#993] STM32H7: Connect USART RX DMA requests

### DIFF
--- a/platforms/cpus/stm32h7.repl
+++ b/platforms/cpus/stm32h7.repl
@@ -294,6 +294,7 @@ usart6: UART.STM32F7_USART @ {
     }
     frequency: 200000000
     IRQ -> exti@29
+    ReceiveDmaRequest -> dmamux1@71
 
 usart1: UART.STM32F7_USART @ {
         sysbus 0x40011000;
@@ -301,6 +302,7 @@ usart1: UART.STM32F7_USART @ {
     }
     frequency: 200000000
     IRQ -> exti@26
+    ReceiveDmaRequest -> dmamux1@41
 
 timer8: Timers.STM32_Timer @ {
         sysbus 0x40010400;
@@ -330,6 +332,7 @@ uart8: UART.STM32F7_USART @ {
     }
     frequency: 125000000
     IRQ -> exti@33
+    ReceiveDmaRequest -> dmamux1@81
 
 uart7: UART.STM32F7_USART @ {
         sysbus 0x40007800;
@@ -337,6 +340,7 @@ uart7: UART.STM32F7_USART @ {
     }
     frequency: 125000000
     IRQ -> exti@32
+    ReceiveDmaRequest -> dmamux1@79
 
 i2c3: I2C.STM32F7_I2C @ {
         sysbus 0x40005C00;
@@ -365,6 +369,7 @@ uart5: UART.STM32F7_USART @ {
     }
     frequency: 125000000
     IRQ -> exti@31
+    ReceiveDmaRequest -> dmamux1@65
 
 uart4: UART.STM32F7_USART @ {
         sysbus 0x40004C00;
@@ -372,6 +377,7 @@ uart4: UART.STM32F7_USART @ {
     }
     frequency: 125000000
     IRQ -> exti@30
+    ReceiveDmaRequest -> dmamux1@63
 
 usart3: UART.STM32F7_USART @ {
         sysbus 0x40004800;
@@ -379,6 +385,7 @@ usart3: UART.STM32F7_USART @ {
     }
     frequency: 125000000
     IRQ -> exti@28
+    ReceiveDmaRequest -> dmamux1@45
 
 usart2: UART.STM32F7_USART @ {
         sysbus 0x40004400;
@@ -386,6 +393,7 @@ usart2: UART.STM32F7_USART @ {
     }
     frequency: 125000000
     IRQ -> exti@27
+    ReceiveDmaRequest -> dmamux1@43
 
 timer14: Timers.STM32_Timer @ {
         sysbus 0x40002000;


### PR DESCRIPTION
### Related issue

#993

### Description

Bug fix, one half of #993.

`platforms/cpus/stm32h7.repl` never connected the USART/UART DMA request lines. `STM32DMA`'s peripheral-to-memory streams are driven exclusively by their DMA request GPIO —
`Stream.HandleEnable` performs an immediate transfer only when the direction is *not* `PeripheralToMemory`:

```csharp
private void HandleEnable(bool value)
{
    // Only transfers from peripheral are using interrupt driven approach.
    // In other cases we can just transfer all data immediately.
    if(value && direction.Value != Direction.PeripheralToMemory)
    {
        PerformTransfer();
    }
}
```

With no request line wired, `Stream.OnGPIO` is never called for a USART, so DMA-based UART RX never transfers a byte.

The model side was already in place: `STM32F7_USART` exposes `ReceiveDmaRequest`, asserted from `BufferState` whenever `CR3.DMAR` is set. Only the platform wiring was missing. Other STM32
platforms already do this — `stm32f0.repl` has `DMAReceive -> dma@2`, `stm32f103.repl` has `DMARequest -> dma1@4 | dma1@5`.

Request IDs are the DMAMUX1 `*_rx_dma` lines from RM0433:

| peripheral | request | peripheral | request |
|---|---|---|---|
| usart1 | 41 | uart5 | 65 |
| usart2 | 43 | usart6 | 71 |
| usart3 | 45 | uart7 | 79 |
| uart4 | 63 | uart8 | 81 |

Only RX lines are added. Memory-to-peripheral transfers already complete immediately in the model, so TX needs no request signal.

### Usage example

Boot any STM32H7 machine (e.g. `platforms/boards/nucleo_h743zi.repl`) with firmware that sets `CR3.DMAR` and reads over DMA — a Zephyr app using the async UART API, or an `embassy-stm32` app
using `RingBufferedUartRx`. Feed bytes in with `sysbus.usart3 WriteChar` or a socket terminal.

Before: nothing arrives, and `logLevel -1 dma1` shows no transfer. After: the bytes land in the guest's DMA buffer.

### Additional information

This change alone is not sufficient to fix #993 — bytes reach the DMA ring, but a driver waiting on the idle line still never wakes, because `IDLE` is unimplemented in `STM32F7_USART` and
`STM32DMA` raises no half-transfer interrupt. The model-side half is renode/renode-infrastructure#247. Please consider the two together.